### PR TITLE
Address Possible Bug in Retrospective Analysis

### DIFF
--- a/src/batchie/cli/calculate_distance_matrix.py
+++ b/src/batchie/cli/calculate_distance_matrix.py
@@ -118,8 +118,8 @@ def main():
 
     data = Screen.load_h5(args.data)
 
-    args.model_params[N_UNIQUE_SAMPLES] = data.n_unique_samples
-    args.model_params[N_UNIQUE_TREATMENTS] = data.n_unique_treatments
+    args.model_params[N_UNIQUE_SAMPLES] = data.sample_space_size
+    args.model_params[N_UNIQUE_TREATMENTS] = data.treatment_space_size
 
     model: BayesianModel = args.model_cls(**args.model_params)
 

--- a/src/batchie/cli/calculate_scores.py
+++ b/src/batchie/cli/calculate_scores.py
@@ -139,8 +139,8 @@ def main():
 
     screen = Screen.load_h5(args.data)
 
-    args.model_params[N_UNIQUE_SAMPLES] = screen.n_unique_samples
-    args.model_params[N_UNIQUE_TREATMENTS] = screen.n_unique_treatments
+    args.model_params[N_UNIQUE_SAMPLES] = screen.sample_space_size
+    args.model_params[N_UNIQUE_TREATMENTS] = screen.treatment_space_size
 
     model: BayesianModel = args.model_cls(**args.model_params)
 

--- a/src/batchie/cli/evaluate_model.py
+++ b/src/batchie/cli/evaluate_model.py
@@ -93,8 +93,8 @@ def main():
 
     training_screen = Screen.load_h5(args.training_screen)
 
-    args.model_params[N_UNIQUE_SAMPLES] = training_screen.n_unique_samples
-    args.model_params[N_UNIQUE_TREATMENTS] = training_screen.n_unique_treatments
+    args.model_params[N_UNIQUE_SAMPLES] = training_screen.sample_space_size
+    args.model_params[N_UNIQUE_TREATMENTS] = training_screen.treatment_space_size
 
     model: BayesianModel = args.model_cls(**args.model_params)
 

--- a/src/batchie/cli/train_model.py
+++ b/src/batchie/cli/train_model.py
@@ -112,8 +112,8 @@ def main():
 
     data = Screen.load_h5(args.data)
 
-    args.model_params[N_UNIQUE_SAMPLES] = data.n_unique_samples
-    args.model_params[N_UNIQUE_TREATMENTS] = data.n_unique_treatments
+    args.model_params[N_UNIQUE_SAMPLES] = data.sample_space_size
+    args.model_params[N_UNIQUE_TREATMENTS] = data.treatment_space_size
 
     model: BayesianModel = args.model_cls(**args.model_params)
 

--- a/src/batchie/data_test.py
+++ b/src/batchie/data_test.py
@@ -19,29 +19,99 @@ from batchie.data import (
 
 
 def test_encode_treatment_arrays_to_0_indexed_ids():
-    result = encode_treatment_arrays_to_0_indexed_ids(
+    result, treatments, doses, ids = encode_treatment_arrays_to_0_indexed_ids(
         treatment_name_arr=np.array(["a", "b", "a", "b"]),
         treatment_dose_arr=np.array([1, 2, 3, 4]),
     )
 
-    np.testing.assert_array_equal(result, np.array([0, 1, 2, 3]))
+    np.testing.assert_array_equal(result, np.array([0, 2, 1, 3]))
+
+    assert dict(zip(zip(treatments, doses), ids)) == {
+        ("a", 1): 0,
+        ("b", 2): 2,
+        ("a", 3): 1,
+        ("b", 4): 3,
+    }
+
+
+def test_encode_treatment_arrays_to_0_indexed_ids_existing_mapping():
+    result, treatments, doses, ids = encode_treatment_arrays_to_0_indexed_ids(
+        treatment_name_arr=np.array(["a", "b", "a", "b"]),
+        treatment_dose_arr=np.array([1, 2, 3, 4]),
+        existing_mapping=(
+            np.array(["a", "a", "b", "b"]),
+            np.array([1, 3, 2, 4]),
+            np.array([1, 2, 3, 4]),
+        ),
+    )
+
+    np.testing.assert_array_equal(result, np.array([1, 3, 2, 4]))
+
+    assert dict(zip(zip(treatments, doses), ids)) == {
+        ("a", 1): 1,
+        ("b", 2): 3,
+        ("a", 3): 2,
+        ("b", 4): 4,
+    }
+
+
+def test_encode_treatment_arrays_to_0_indexed_ids_bad_existing_mapping():
+    with pytest.raises(ValueError):
+        result, treatments, doses, ids = encode_treatment_arrays_to_0_indexed_ids(
+            treatment_name_arr=np.array(["a", "b", "a", "b"]),
+            treatment_dose_arr=np.array([1, 2, 3, 4]),
+            existing_mapping=(
+                np.array(["c", "a", "b", "b"]),
+                np.array([1, 3, 2, 4]),
+                np.array([0, 1, 2, 3]),
+            ),
+        )
 
 
 def test_encode_treatment_arrays_with_controls_to_0_indexed_ids():
-    result = encode_treatment_arrays_to_0_indexed_ids(
+    result, treatments, doses, ids = encode_treatment_arrays_to_0_indexed_ids(
         treatment_name_arr=np.array(["a", "b", "", "b", "", "a"], dtype=object),
         treatment_dose_arr=np.array([1, 2, 3, 0, 0, 1]),
         control_treatment_name="",
     )
 
     np.testing.assert_array_equal(result, np.array([0, 1, -1, -1, -1, 0]))
+    assert dict(zip(zip(treatments, doses), ids)) == {
+        ("", 0): -1,
+        ("", 3): -1,
+        ("a", 1): 0,
+        ("b", 0): -1,
+        ("b", 2): 1,
+    }
 
 
 def test_encode_1d_array_to_0_indexed_ids():
-    result = encode_1d_array_to_0_indexed_ids(np.array(["a", "b", "c", "a"]))
+    result, values, ids = encode_1d_array_to_0_indexed_ids(
+        np.array(["a", "b", "c", "a"])
+    )
+    assert dict(zip(values, ids)) == {"a": 0, "b": 1, "c": 2}
     np.testing.assert_array_equal(result, np.array([0, 1, 2, 0]))
-    result = encode_1d_array_to_0_indexed_ids(np.array(["a", "a", "b", "b"], dtype=str))
+    result, values, ids = encode_1d_array_to_0_indexed_ids(
+        np.array(["a", "a", "b", "b"], dtype=str)
+    )
+    assert dict(zip(values, ids)) == {"a": 0, "b": 1}
     np.testing.assert_array_equal(result, np.array([0, 0, 1, 1]))
+
+
+def test_encode_1d_array_to_0_indexed_ids_existing_mapping():
+    result, values, ids = encode_1d_array_to_0_indexed_ids(
+        np.array(["a", "b", "c", "a"]),
+        existing_mapping=(np.array(["a", "b", "c"]), np.array([1, 2, 3])),
+    )
+    assert dict(zip(values, ids)) == {"a": 1, "b": 2, "c": 3}
+
+
+def test_encode_1d_array_to_0_indexed_ids_bad_existing_mapping():
+    with pytest.raises(ValueError):
+        result, values, ids = encode_1d_array_to_0_indexed_ids(
+            np.array(["a", "b", "c", "a"]),
+            existing_mapping=(np.array(["d", "b", "c"]), np.array([1, 2, 3])),
+        )
 
 
 def test_screen_props():
@@ -122,63 +192,19 @@ def test_screen_hardcode_ids():
             [["a", "b"], ["a", "b"], ["a", "b"], ["a", "b"]], dtype=str
         ),
         treatment_doses=np.array([[2.0, 2.0], [1.0, 2.0], [2.0, 1.0], [2.0, 0]]),
-        treatment_ids=np.array([[0, 1], [0, 9], [0, 1], [0, 1]]),
-        sample_ids=np.array([0, 1, 4, 5]),
-        plate_ids=np.array([0, 0, 2, 2]),
+        treatment_mapping=(
+            np.array(["a", "a", "b", "b", "b"]),
+            np.array([1.0, 2.0, 1.0, 2.0, 0]),
+            np.array([0, 1, 2, 3, -1]),
+        ),
+        sample_mapping=(np.array(["a", "b", "c", "d"]), np.array([0, 1, 2, 3])),
     )
 
     np.testing.assert_array_equal(
-        screen.treatment_ids, np.array([[0, 1], [0, 9], [0, 1], [0, 1]])
+        screen.treatment_ids, np.array([[1, 3], [0, 3], [1, 2], [1, -1]])
     )
 
-    np.testing.assert_array_equal(screen.sample_ids, np.array([0, 1, 4, 5]))
-
-    np.testing.assert_array_equal(screen.plate_ids, np.array([0, 0, 2, 2]))
-
-    with pytest.raises(ValueError):
-        Screen(
-            observations=np.array([0.1, 0.2, 0, 0]),
-            observation_mask=np.array([True, True, False, False]),
-            sample_names=np.array(["a", "b", "c", "d"], dtype=str),
-            plate_names=np.array(["a", "a", "b", "b"], dtype=str),
-            treatment_names=np.array(
-                [["a", "b"], ["a", "b"], ["a", "b"], ["a", "b"]], dtype=str
-            ),
-            treatment_doses=np.array([[2.0, 2.0], [1.0, 2.0], [2.0, 1.0], [2.0, 0]]),
-            treatment_ids=np.array([[0, 1], [0, 9], [0, 1], [0, 1]]),
-            sample_ids=np.array([0, 1, 4]),
-            plate_ids=np.array([0, 0, 2, 2]),
-        )
-
-    with pytest.raises(ValueError):
-        Screen(
-            observations=np.array([0.1, 0.2, 0, 0]),
-            observation_mask=np.array([True, True, False, False]),
-            sample_names=np.array(["a", "b", "c", "d"], dtype=str),
-            plate_names=np.array(["a", "a", "b", "b"], dtype=str),
-            treatment_names=np.array(
-                [["a", "b"], ["a", "b"], ["a", "b"], ["a", "b"]], dtype=str
-            ),
-            treatment_doses=np.array([[2.0, 2.0], [1.0, 2.0], [2.0, 1.0], [2.0, 0]]),
-            treatment_ids=np.array([[0, 1], [0, 9], [0, 1], [0, 1]]),
-            sample_ids=np.array([0, 1, 4, 3]),
-            plate_ids=np.array([0, 0, 2]),
-        )
-
-    with pytest.raises(ValueError):
-        Screen(
-            observations=np.array([0.1, 0.2, 0, 0]),
-            observation_mask=np.array([True, True, False, False]),
-            sample_names=np.array(["a", "b", "c", "d"], dtype=str),
-            plate_names=np.array(["a", "a", "b", "b"], dtype=str),
-            treatment_names=np.array(
-                [["a", "b"], ["a", "b"], ["a", "b"], ["a", "b"]], dtype=str
-            ),
-            treatment_doses=np.array([[2.0, 2.0], [1.0, 2.0], [2.0, 1.0]]),
-            treatment_ids=np.array([[0, 1], [0, 9], [0, 1], [0, 1]]),
-            sample_ids=np.array([0, 1, 4, 3]),
-            plate_ids=np.array([0, 0, 2, 2]),
-        )
+    np.testing.assert_array_equal(screen.sample_ids, np.array([0, 1, 2, 3]))
 
 
 def test_screen_subset_props():
@@ -388,7 +414,7 @@ def test_screen_subset():
     np.testing.assert_array_equal(subset.sample_ids, [0, 3])
     np.testing.assert_array_equal(subset.plate_ids, [0, 1])
     np.testing.assert_array_equal(
-        subset.treatment_ids, [[0, CONTROL_SENTINEL_VALUE], [CONTROL_SENTINEL_VALUE, 4]]
+        subset.treatment_ids, [[0, CONTROL_SENTINEL_VALUE], [CONTROL_SENTINEL_VALUE, 2]]
     )
 
     inverted_subset = subset.invert()

--- a/src/batchie/retrospective.py
+++ b/src/batchie/retrospective.py
@@ -635,9 +635,8 @@ def create_random_holdout(
         plate_names=screen.plate_names[~selection_vector],
         control_treatment_name=screen.control_treatment_name,
         observation_mask=screen.observation_mask[~selection_vector],
-        treatment_ids=screen.treatment_ids[~selection_vector],
-        sample_ids=screen.sample_ids[~selection_vector],
-        plate_ids=screen.plate_ids[~selection_vector],
+        sample_mapping=screen.sample_mapping,
+        treatment_mapping=screen.treatment_mapping,
     )
 
     holdout_screen = Screen(
@@ -648,9 +647,8 @@ def create_random_holdout(
         plate_names=screen.plate_names[selection_vector],
         control_treatment_name=screen.control_treatment_name,
         observation_mask=np.ones(np.count_nonzero(selection_vector), dtype=bool),
-        treatment_ids=screen.treatment_ids[selection_vector],
-        sample_ids=screen.sample_ids[selection_vector],
-        plate_ids=screen.plate_ids[selection_vector],
+        sample_mapping=screen.sample_mapping,
+        treatment_mapping=screen.treatment_mapping,
     )
 
     return keep_screen, holdout_screen
@@ -697,9 +695,8 @@ def create_plate_balanced_holdout_set_among_masked_plates(
         plate_names=screen.plate_names[~selection_vector],
         control_treatment_name=screen.control_treatment_name,
         observation_mask=screen.observation_mask[~selection_vector],
-        treatment_ids=screen.treatment_ids[~selection_vector],
-        sample_ids=screen.sample_ids[~selection_vector],
-        plate_ids=screen.plate_ids[~selection_vector],
+        treatment_mapping=screen.treatment_mapping,
+        sample_mapping=screen.sample_mapping,
     )
 
     holdout_screen = Screen(
@@ -710,9 +707,8 @@ def create_plate_balanced_holdout_set_among_masked_plates(
         plate_names=screen.plate_names[selection_vector],
         control_treatment_name=screen.control_treatment_name,
         observation_mask=np.ones(np.count_nonzero(selection_vector), dtype=bool),
-        treatment_ids=screen.treatment_ids[selection_vector],
-        sample_ids=screen.sample_ids[selection_vector],
-        plate_ids=screen.plate_ids[selection_vector],
+        treatment_mapping=screen.treatment_mapping,
+        sample_mapping=screen.sample_mapping,
     )
 
     return keep_screen, holdout_screen


### PR DESCRIPTION
When we do our train test split for retrospective analysis, if we got into a situation where not all treatment_ids and or sample_ids were represented at least once in the train split, it could cause a problem.

The solution is to allow a screen to carry its "sample universe size" and "treatment universe size" so we can use these numbers to configure the model, instead of number of unique treatments and number of unique samples, which could be wrong.