### PR TITLE
Allow dbal to score experiments that exhibit different variances

### DIFF
--- a/src/batchie/scoring/gaussian_dbal.py
+++ b/src/batchie/scoring/gaussian_dbal.py
@@ -56,7 +56,8 @@ def pad_ragged_arrays_to_dense_array(arrays: list[ArrayType], pad_value: float =
     Given a list of arrays, each with N dimensions,
     each of which have different sizes, return a dense array of N + 1 dimensions,
     of size (len(array), maximum_of_dimension_0, ... maximum_of_dimension_N)
-    where all the arrays are padded to the maximum size.
+    where all the arrays are padded to the maximum size. 
+    Padding value defaults to 0.
 
     :param arrays: A list of arrays
     :param pad_value: A floating point number (default is 0)

--- a/src/batchie/scoring/gaussian_dbal_test.py
+++ b/src/batchie/scoring/gaussian_dbal_test.py
@@ -81,7 +81,7 @@ def test_iter_combination():
 def test_zero_pad_ragged_arrays_to_dense_array():
     arrs = [np.ones((2, 3)), np.ones((5, 5))]
 
-    result = gaussian_dbal.zero_pad_ragged_arrays_to_dense_array(arrs)
+    result = gaussian_dbal.pad_ragged_arrays_to_dense_array(arrs)
 
     assert result.sum() == 25 + 6
     assert result[0, :, :].sum() == 6


### PR DESCRIPTION
Changed `dbal_fast_gauss_scoring_vec` so that variances can now be either an array or a list of arrays. 

This allows BATCHIE to work with models that assign different variances to different experiments.