### PR TITLE
Cleanup Model Type Branching, Add Test Coverage

### DIFF
--- a/.github/workflows/python-black.yml
+++ b/.github/workflows/python-black.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with:
-           version: "~= 23.1"
+           version: "~= 24.1.1"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,14 +10,14 @@ repos:
       - id: check-added-large-files
       - id: check-merge-conflict
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 24.1.1
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.9
+        language_version: python3.11
   - repo: https://github.com/conorfalvey/check_pdb_hook
     rev: 0.0.9
     hooks:

--- a/nextflow/scripts/test.yml
+++ b/nextflow/scripts/test.yml
@@ -1,10 +1,10 @@
 - name: run_retrospective_simulation
-  command: python nextflow/scripts/batchie.py --mode retrospective -c nextflow/tests/config/integration_test_retrospective_simulation.config --batch-size 3 --screen nextflow/tests/data/unmasked_screen.h5 --outdir retrospective_sim --n_chains 2 --n_chunks 2 -profile docker
+  command: python nextflow/scripts/batchie.py --mode retrospective -c nextflow/tests/config/integration_test_retrospective_simulation.config --batch-size 3 --screen nextflow/tests/data/unmasked_screen.h5 --outdir retrospective_sim --n_chains 2 --n_chunks 2 --max_cpus 1 --max_mem 1GB -profile docker
   tags:
     - run_retrospective_simulation
   files: []
 - name: run_prospective_batch
-  command: python nextflow/scripts/batchie.py --mode prospective -c nextflow/tests/config/integration_test_retrospective_simulation.config --batch-size 3 --screen nextflow/tests/data/masked_screen.h5 --outdir prospective_sim --n_chains 2 --n_chunks 2 -profile docker
+  command: python nextflow/scripts/batchie.py --mode prospective -c nextflow/tests/config/integration_test_retrospective_simulation.config --batch-size 3 --screen nextflow/tests/data/masked_screen.h5 --outdir prospective_sim --n_chains 2 --n_chunks 2 --max_cpus 1 --max_mem 1GB -profile docker
   tags:
     - run_prospective_batch
   files: []

--- a/nextflow/tests/config/integration_test_retrospective_simulation.config
+++ b/nextflow/tests/config/integration_test_retrospective_simulation.config
@@ -16,6 +16,13 @@ process {
         ].join(' ')
     }
 
+    withName: ANALYZE_MODEL_EVALUATION {
+        ext.args = [
+            '--model', 'SparseDrugCombo',
+            '--model-param', 'n_embedding_dimensions=2'
+        ].join(' ')
+    }
+
     withName: CALCULATE_SCORE_CHUNK {
         ext.args = [
             '--model', 'SparseDrugCombo',

--- a/nextflow/tests/workflows/nf-core/batchie/retrospective_simulation/iter.config
+++ b/nextflow/tests/workflows/nf-core/batchie/retrospective_simulation/iter.config
@@ -27,6 +27,13 @@ process {
         ].join(' ')
     }
 
+    withName: ANALYZE_MODEL_EVALUATION {
+        ext.args = [
+            '--model', 'SparseDrugCombo',
+            '--model-param', 'n_embedding_dimensions=2'
+        ].join(' ')
+    }
+
     withName: CALCULATE_SCORE_CHUNK {
         ext.args = [
             '--model', 'SparseDrugCombo',

--- a/nextflow/tests/workflows/nf-core/batchie/retrospective_simulation/nextflow.config
+++ b/nextflow/tests/workflows/nf-core/batchie/retrospective_simulation/nextflow.config
@@ -26,6 +26,13 @@ process {
         ].join(' ')
     }
 
+    withName: ANALYZE_MODEL_EVALUATION {
+        ext.args = [
+            '--model', 'SparseDrugCombo',
+            '--model-param', 'n_embedding_dimensions=2'
+        ].join(' ')
+    }
+
     withName: CALCULATE_SCORE_CHUNK {
         ext.args = [
             '--model', 'SparseDrugCombo',

--- a/src/batchie/core.py
+++ b/src/batchie/core.py
@@ -244,7 +244,7 @@ class BayesianModel(ABC):
         raise NotImplementedError
 
 
-class MCMCModel(BayesianModel):
+class MCMCModel:
     """
     This class subclasses BayesianModel and implements :py:meth:`batchie.core.MCMCModel.step`
     """
@@ -261,7 +261,7 @@ class MCMCModel(BayesianModel):
         raise NotImplementedError
 
 
-class VIModel(BayesianModel):
+class VIModel:
     """
     This class subclasses BayesianModel and implements :py:meth:`batchie.core.VIModel.sample`
     """
@@ -275,7 +275,7 @@ class VIModel(BayesianModel):
         raise NotImplementedError
 
 
-class HomoscedasticBayesianModel(BayesianModel):
+class HomoscedasticModel:
     @abstractmethod
     def variance(self, data: ScreenBase) -> FloatingPointType:
         """
@@ -286,7 +286,7 @@ class HomoscedasticBayesianModel(BayesianModel):
         raise NotImplementedError
 
 
-class HeteroscedasticBayesianModel(BayesianModel):
+class HeteroscedasticModel:
     @abstractmethod
     def variance(self, data: ScreenBase) -> ArrayType:
         """

--- a/src/batchie/core.py
+++ b/src/batchie/core.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from abc import ABC, abstractmethod
-from typing import Union
+from typing import Generic, TypeVar
 import numpy as np
 
 from batchie.common import ArrayType, FloatingPointType
@@ -124,7 +124,10 @@ class ThetaHolder(ABC):
         return first
 
 
-class BayesianModel(ABC):
+V = TypeVar("V")
+
+
+class BayesianModel(ABC, Generic[V]):
     """
     This class represents a Bayesian model.
 
@@ -187,11 +190,9 @@ class BayesianModel(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def variance(self, data: ScreenBase) -> Union[FloatingPointType, ArrayType]:
+    def variance(self, data: ScreenBase) -> V:
         """
         Return the variance of the model.
-
-        :return: A single floating point number or an array of variances for each item in the Experiment.
         """
         raise NotImplementedError
 
@@ -266,6 +267,18 @@ class MCMCModel(BayesianModel):
 
         In the case of an MCMC model, this would mean taking one more MCMC step. Other types
         of models should implement accordingly.
+
+        """
+        raise NotImplementedError
+
+
+class HomoscedasticBayesianModel(BayesianModel):
+    @abstractmethod
+    def variance(self, data: ScreenBase) -> FloatingPointType:
+        """
+        Return the variance of the model.
+
+        :return: A single floating point number representing the variance of this models predictions.
         """
         raise NotImplementedError
 
@@ -279,6 +292,18 @@ class VIModel(BayesianModel):
     def sample(self, num_samples: int) -> list[Theta]:
         """
         Returns a list of Theta samples. Length of the list should be num_samples.
+
+        """
+        raise NotImplementedError
+
+
+class HeteroscedasticBayesianModel(BayesianModel):
+    @abstractmethod
+    def variance(self, data: ScreenBase) -> ArrayType:
+        """
+        Return the variance of the model.
+
+        :return: An array containing the variance of the prediction for each experiment in the screen.
         """
         raise NotImplementedError
 

--- a/src/batchie/core.py
+++ b/src/batchie/core.py
@@ -1,7 +1,6 @@
 import json
 import logging
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar
 import numpy as np
 
 from batchie.common import ArrayType, FloatingPointType
@@ -124,10 +123,7 @@ class ThetaHolder(ABC):
         return first
 
 
-V = TypeVar("V")
-
-
-class BayesianModel(ABC, Generic[V]):
+class BayesianModel(ABC):
     """
     This class represents a Bayesian model.
 
@@ -186,13 +182,6 @@ class BayesianModel(ABC, Generic[V]):
         Predict the outcome of an :py:class:`batchie.data.ExperimentBase`.
 
         :return: An array of predictions for each item in the Experiment.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def variance(self, data: ScreenBase) -> V:
-        """
-        Return the variance of the model.
         """
         raise NotImplementedError
 
@@ -272,17 +261,6 @@ class MCMCModel(BayesianModel):
         raise NotImplementedError
 
 
-class HomoscedasticBayesianModel(BayesianModel):
-    @abstractmethod
-    def variance(self, data: ScreenBase) -> FloatingPointType:
-        """
-        Return the variance of the model.
-
-        :return: A single floating point number representing the variance of this models predictions.
-        """
-        raise NotImplementedError
-
-
 class VIModel(BayesianModel):
     """
     This class subclasses BayesianModel and implements :py:meth:`batchie.core.VIModel.sample`
@@ -293,6 +271,17 @@ class VIModel(BayesianModel):
         """
         Returns a list of Theta samples. Length of the list should be num_samples.
 
+        """
+        raise NotImplementedError
+
+
+class HomoscedasticBayesianModel(BayesianModel):
+    @abstractmethod
+    def variance(self, data: ScreenBase) -> FloatingPointType:
+        """
+        Return the variance of the model.
+
+        :return: A single floating point number representing the variance of this models predictions.
         """
         raise NotImplementedError
 

--- a/src/batchie/fast_mvn.py
+++ b/src/batchie/fast_mvn.py
@@ -1,4 +1,5 @@
 """Methods for sampling from multivariate normal distributions."""
+
 import numpy as np
 import scipy as sp
 from scipy.linalg import solve_triangular

--- a/src/batchie/models/main.py
+++ b/src/batchie/models/main.py
@@ -150,7 +150,7 @@ def get_heteroescedastic_variances(
     :param model: The model to use for prediction
     :param screen: The data to predict
     :param thetas: The set of model parameters to use for prediction
-    :return: A matrix of shape (n_samples, n_experiments) containing the
+    :return: A matrix of shape (n_thetas, n_experiments) containing the
              prediction variances for each model / experiment combination.
     """
 

--- a/src/batchie/models/main.py
+++ b/src/batchie/models/main.py
@@ -9,8 +9,8 @@ import pandas
 from batchie.common import FloatingPointType, ArrayType, CONTROL_SENTINEL_VALUE
 from batchie.core import (
     BayesianModel,
-    HomoscedasticBayesianModel,
-    HeteroscedasticBayesianModel,
+    HomoscedasticModel,
+    HeteroscedasticModel,
     ThetaHolder,
 )
 from batchie.data import ScreenBase, Screen
@@ -116,9 +116,7 @@ def predict_all(model: BayesianModel, screen: ScreenBase, thetas: ThetaHolder):
     return result
 
 
-def get_homoescedastic_variances(
-    model: HomoscedasticBayesianModel, screen: ScreenBase, thetas: ThetaHolder
-):
+def get_homoescedastic_variances(model, screen: ScreenBase, thetas: ThetaHolder):
     """
     Get the variance for the experiment data using the model parameterized with each theta in thetas.
 
@@ -141,9 +139,7 @@ def get_homoescedastic_variances(
     return np.array(results, dtype=FloatingPointType)
 
 
-def get_heteroescedastic_variances(
-    model: HeteroscedasticBayesianModel, screen: ScreenBase, thetas: ThetaHolder
-):
+def get_heteroescedastic_variances(model, screen: ScreenBase, thetas: ThetaHolder):
     """
     Get the variance for the experiment data using the model parameterized with each theta in thetas.
 

--- a/src/batchie/models/main.py
+++ b/src/batchie/models/main.py
@@ -7,7 +7,12 @@ from itertools import combinations
 import pandas
 
 from batchie.common import FloatingPointType, ArrayType, CONTROL_SENTINEL_VALUE
-from batchie.core import BayesianModel, ThetaHolder
+from batchie.core import (
+    BayesianModel,
+    HomoscedasticBayesianModel,
+    HeteroscedasticBayesianModel,
+    ThetaHolder,
+)
 from batchie.data import ScreenBase, Screen
 
 
@@ -111,7 +116,34 @@ def predict_all(model: BayesianModel, screen: ScreenBase, thetas: ThetaHolder):
     return result
 
 
-def variance_all(model: BayesianModel, screen: ScreenBase, thetas: ThetaHolder):
+def get_homoescedastic_variances(
+    model: HomoscedasticBayesianModel, screen: ScreenBase, thetas: ThetaHolder
+):
+    """
+    Get the variance for the experiment data using the model parameterized with each theta in thetas.
+
+    :param model: The model to use for prediction
+    :param screen: The data to predict
+    :param thetas: The set of model parameters to use for prediction
+    :return: A vector of shape (n_thetas,)
+    """
+
+    results = []
+    for theta_index in range(thetas.n_thetas):
+        model.set_model_state(thetas.get_theta(theta_index))
+        result = model.variance(screen)
+        results.append(result)
+        if np.isnan(result):
+            raise ValueError(
+                "NaN predictions were created, please check screen and theta values"
+            )
+
+    return np.array(results, dtype=FloatingPointType)
+
+
+def get_heteroescedastic_variances(
+    model: HeteroscedasticBayesianModel, screen: ScreenBase, thetas: ThetaHolder
+):
     """
     Get the variance for the experiment data using the model parameterized with each theta in thetas.
 
@@ -119,14 +151,19 @@ def variance_all(model: BayesianModel, screen: ScreenBase, thetas: ThetaHolder):
     :param screen: The data to predict
     :param thetas: The set of model parameters to use for prediction
     :return: A matrix of shape (n_samples, n_experiments) containing the
-             predictions for each model / experiment combination,
-             or a vector of shape (n_samples,).
+             prediction variances for each model / experiment combination.
     """
 
     results = []
     for theta_index in range(thetas.n_thetas):
         model.set_model_state(thetas.get_theta(theta_index))
         result = model.variance(screen)
+
+        if not result.size == screen.size:
+            raise ValueError(
+                "The variance array returned by the model is not the same size as the screen"
+            )
+
         results.append(result)
         if np.any(np.isnan(result)):
             raise ValueError(

--- a/src/batchie/models/main_test.py
+++ b/src/batchie/models/main_test.py
@@ -7,8 +7,8 @@ import numpy as np
 from batchie.common import FloatingPointType
 from batchie.core import (
     BayesianModel,
-    HomoscedasticBayesianModel,
-    HeteroscedasticBayesianModel,
+    HomoscedasticModel,
+    HeteroscedasticModel,
     ThetaHolder,
 )
 from batchie.data import Screen
@@ -143,7 +143,7 @@ def test_correlation_matrix(mocker, screen):
 
 
 def test_get_homoescedastic_variances(mocker, screen):
-    model = mocker.MagicMock(spec=HomoscedasticBayesianModel)
+    model = mocker.Mock()
     thetas = mocker.MagicMock(spec=ThetaHolder)
     model.variance.side_effect = [1, 2, 3]
     thetas.n_thetas = 3
@@ -153,7 +153,7 @@ def test_get_homoescedastic_variances(mocker, screen):
 
 
 def test_get_heteroescedastic_variances(mocker, screen):
-    model = mocker.MagicMock(spec=HomoscedasticBayesianModel)
+    model = mocker.Mock()
     thetas = mocker.MagicMock(spec=ThetaHolder)
 
     model.variance.side_effect = [
@@ -174,7 +174,7 @@ def test_get_heteroescedastic_variances(mocker, screen):
 
 
 def test_get_heteroescedastic_variances_raises_wrong_shape(mocker, screen):
-    model = mocker.MagicMock(spec=HomoscedasticBayesianModel)
+    model = mocker.Mock()
     thetas = mocker.MagicMock(spec=ThetaHolder)
 
     model.variance.side_effect = [
@@ -189,7 +189,7 @@ def test_get_heteroescedastic_variances_raises_wrong_shape(mocker, screen):
 
 
 def test_get_homoescedastic_variances_raises_on_na(mocker, screen):
-    model = mocker.MagicMock(spec=HomoscedasticBayesianModel)
+    model = mocker.Mock()
     thetas = mocker.MagicMock(spec=ThetaHolder)
     model.variance.side_effect = [1, 2, np.nan]
     thetas.n_thetas = 3
@@ -199,7 +199,7 @@ def test_get_homoescedastic_variances_raises_on_na(mocker, screen):
 
 
 def test_get_heteroescedastic_variances_raises_on_na(mocker, screen):
-    model = mocker.MagicMock(spec=HomoscedasticBayesianModel)
+    model = mocker.Mock()
     thetas = mocker.MagicMock(spec=ThetaHolder)
 
     model.variance.side_effect = [

--- a/src/batchie/models/main_test.py
+++ b/src/batchie/models/main_test.py
@@ -74,7 +74,7 @@ def test_model_evaluation_rmse():
     assert me.rmse() > 0
 
 
-def test_predict_all(mocker):
+def test_predict_all(mocker, screen):
     model = mocker.MagicMock(spec=BayesianModel)
     thetas = mocker.MagicMock(spec=ThetaHolder)
 

--- a/src/batchie/models/main_test.py
+++ b/src/batchie/models/main_test.py
@@ -5,9 +5,31 @@ import pytest
 import numpy as np
 
 from batchie.common import FloatingPointType
-from batchie.core import BayesianModel, ThetaHolder
+from batchie.core import (
+    BayesianModel,
+    HomoscedasticBayesianModel,
+    HeteroscedasticBayesianModel,
+    ThetaHolder,
+)
 from batchie.data import Screen
 from batchie.models import main
+
+
+@pytest.fixture(scope="module")
+def screen():
+    return Screen(
+        observations=np.array([0.1, 0.2, 0, 0, 0, 0]),
+        observation_mask=np.array([True, True, False, False, False, False]),
+        sample_names=np.array(["a", "a", "b", "b", "c", "c"], dtype=str),
+        plate_names=np.array(["a", "a", "b", "b", "c", "c"], dtype=str),
+        treatment_names=np.array(
+            [["a", "b"], ["a", "b"], ["a", "b"], ["a", "b"], ["a", "b"], ["a", "b"]],
+            dtype=str,
+        ),
+        treatment_doses=np.array(
+            [[2.0, 2.0], [1.0, 2.0], [2.0, 1.0], [2.0, 0.1], [2.0, 1.0], [2.0, 1.0]]
+        ),
+    )
 
 
 def test_model_evaluation():
@@ -56,20 +78,6 @@ def test_predict_all(mocker):
     model = mocker.MagicMock(spec=BayesianModel)
     thetas = mocker.MagicMock(spec=ThetaHolder)
 
-    screen = Screen(
-        observations=np.array([0.1, 0.2, 0, 0, 0, 0]),
-        observation_mask=np.array([True, True, False, False, False, False]),
-        sample_names=np.array(["a", "a", "b", "b", "c", "c"], dtype=str),
-        plate_names=np.array(["a", "a", "b", "b", "c", "c"], dtype=str),
-        treatment_names=np.array(
-            [["a", "b"], ["a", "b"], ["a", "b"], ["a", "b"], ["a", "b"], ["a", "b"]],
-            dtype=str,
-        ),
-        treatment_doses=np.array(
-            [[2.0, 2.0], [1.0, 2.0], [2.0, 1.0], [2.0, 0.1], [2.0, 1.0], [2.0, 1.0]]
-        ),
-    )
-
     thetas.n_thetas = 5
 
     model.predict.return_value = np.ones((screen.size,), dtype=FloatingPointType)
@@ -79,23 +87,9 @@ def test_predict_all(mocker):
     assert result.shape == (5, 6)
 
 
-def test_predict_avg(mocker):
+def test_predict_avg(mocker, screen):
     model = mocker.MagicMock(spec=BayesianModel)
     thetas = mocker.MagicMock(spec=ThetaHolder)
-
-    screen = Screen(
-        observations=np.array([0.1, 0.2, 0, 0, 0, 0]),
-        observation_mask=np.array([True, True, False, False, False, False]),
-        sample_names=np.array(["a", "a", "b", "b", "c", "c"], dtype=str),
-        plate_names=np.array(["a", "a", "b", "b", "c", "c"], dtype=str),
-        treatment_names=np.array(
-            [["a", "b"], ["a", "b"], ["a", "b"], ["a", "b"], ["a", "b"], ["a", "b"]],
-            dtype=str,
-        ),
-        treatment_doses=np.array(
-            [[2.0, 2.0], [1.0, 2.0], [2.0, 1.0], [2.0, 0.1], [2.0, 1.0], [2.0, 1.0]]
-        ),
-    )
 
     thetas.n_thetas = 5
 
@@ -106,23 +100,9 @@ def test_predict_avg(mocker):
     assert result.shape == (6,)
 
 
-def test_predict_raises_for_bad_values(mocker):
+def test_predict_raises_for_bad_values(mocker, screen):
     model = mocker.MagicMock(spec=BayesianModel)
     thetas = mocker.MagicMock(spec=ThetaHolder)
-
-    screen = Screen(
-        observations=np.array([0.1, 0.2, 0, 0, 0, 0]),
-        observation_mask=np.array([True, True, False, False, False, False]),
-        sample_names=np.array(["a", "a", "b", "b", "c", "c"], dtype=str),
-        plate_names=np.array(["a", "a", "b", "b", "c", "c"], dtype=str),
-        treatment_names=np.array(
-            [["a", "b"], ["a", "b"], ["a", "b"], ["a", "b"], ["a", "b"], ["a", "b"]],
-            dtype=str,
-        ),
-        treatment_doses=np.array(
-            [[2.0, 2.0], [1.0, 2.0], [2.0, 1.0], [2.0, 0.1], [2.0, 1.0], [2.0, 1.0]]
-        ),
-    )
 
     thetas.n_thetas = 5
 
@@ -139,23 +119,9 @@ def test_predict_raises_for_bad_values(mocker):
         main.predict_avg(model, screen, thetas)
 
 
-def test_correlation_matrix(mocker):
+def test_correlation_matrix(mocker, screen):
     model = mocker.MagicMock(spec=BayesianModel)
     thetas = mocker.MagicMock(spec=ThetaHolder)
-
-    screen = Screen(
-        observations=np.array([0.1, 0.2, 0, 0, 0, 0]),
-        observation_mask=np.array([True, True, False, False, False, False]),
-        sample_names=np.array(["a", "a", "b", "b", "c", "c"], dtype=str),
-        plate_names=np.array(["a", "a", "b", "b", "c", "c"], dtype=str),
-        treatment_names=np.array(
-            [["a", "b"], ["a", "b"], ["a", "b"], ["a", "b"], ["a", "b"], ["a", "b"]],
-            dtype=str,
-        ),
-        treatment_doses=np.array(
-            [[2.0, 2.0], [1.0, 2.0], [2.0, 1.0], [2.0, 0.1], [2.0, 1.0], [2.0, 1.0]]
-        ),
-    )
 
     thetas.n_thetas = 5
 
@@ -174,3 +140,74 @@ def test_correlation_matrix(mocker):
 
     assert result.shape == (3, 3)
     assert np.all(result["c"].diff()[1:] > 0)
+
+
+def test_get_homoescedastic_variances(mocker, screen):
+    model = mocker.MagicMock(spec=HomoscedasticBayesianModel)
+    thetas = mocker.MagicMock(spec=ThetaHolder)
+    model.variance.side_effect = [1, 2, 3]
+    thetas.n_thetas = 3
+
+    result = main.get_homoescedastic_variances(model, screen, thetas)
+    np.testing.assert_array_equal(result, np.array([1, 2, 3], dtype=FloatingPointType))
+
+
+def test_get_heteroescedastic_variances(mocker, screen):
+    model = mocker.MagicMock(spec=HomoscedasticBayesianModel)
+    thetas = mocker.MagicMock(spec=ThetaHolder)
+
+    model.variance.side_effect = [
+        np.array([1, 2, 3, 4, 5, 6], dtype=FloatingPointType),
+        np.array([7, 8, 9, 10, 11, 12], dtype=FloatingPointType),
+        np.array([13, 14, 15, 16, 17, 18], dtype=FloatingPointType),
+    ]
+    thetas.n_thetas = 3
+
+    result = main.get_heteroescedastic_variances(model, screen, thetas)
+    np.testing.assert_array_equal(
+        result,
+        np.array(
+            [[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12], [13, 14, 15, 16, 17, 18]],
+            dtype=FloatingPointType,
+        ),
+    )
+
+
+def test_get_heteroescedastic_variances_raises_wrong_shape(mocker, screen):
+    model = mocker.MagicMock(spec=HomoscedasticBayesianModel)
+    thetas = mocker.MagicMock(spec=ThetaHolder)
+
+    model.variance.side_effect = [
+        np.array([1, 2, 3, 4, 5, 6, 1], dtype=FloatingPointType),
+        np.array([7, 8, 9, 10, 11, 12], dtype=FloatingPointType),
+        np.array([13, 14, 15, 16, 17, 18], dtype=FloatingPointType),
+    ]
+    thetas.n_thetas = 3
+
+    with pytest.raises(ValueError):
+        main.get_heteroescedastic_variances(model, screen, thetas)
+
+
+def test_get_homoescedastic_variances_raises_on_na(mocker, screen):
+    model = mocker.MagicMock(spec=HomoscedasticBayesianModel)
+    thetas = mocker.MagicMock(spec=ThetaHolder)
+    model.variance.side_effect = [1, 2, np.nan]
+    thetas.n_thetas = 3
+
+    with pytest.raises(ValueError):
+        main.get_homoescedastic_variances(model, screen, thetas)
+
+
+def test_get_heteroescedastic_variances_raises_on_na(mocker, screen):
+    model = mocker.MagicMock(spec=HomoscedasticBayesianModel)
+    thetas = mocker.MagicMock(spec=ThetaHolder)
+
+    model.variance.side_effect = [
+        np.array([1, 2, 3, 4, 5, np.nan], dtype=FloatingPointType),
+        np.array([7, 8, 9, 10, 11, 12], dtype=FloatingPointType),
+        np.array([13, 14, 15, 16, 17, 18], dtype=FloatingPointType),
+    ]
+    thetas.n_thetas = 3
+
+    with pytest.raises(ValueError):
+        main.get_heteroescedastic_variances(model, screen, thetas)

--- a/src/batchie/models/sparse_combo.py
+++ b/src/batchie/models/sparse_combo.py
@@ -8,7 +8,13 @@ import numpy as np
 from numpy.random import Generator
 from scipy.special import logit, expit
 
-from batchie.core import HomoscedasticBayesianModel, MCMCModel, Theta, ThetaHolder
+from batchie.core import (
+    BayesianModel,
+    HomoscedasticModel,
+    MCMCModel,
+    Theta,
+    ThetaHolder,
+)
 from batchie.data import ScreenBase
 from batchie.fast_mvn import sample_mvn_from_precision
 from batchie.common import (
@@ -691,7 +697,7 @@ class LegacySparseDrugComboImpl:
         return [1.0 / np.sqrt(self.prec)] + self.Mu.tolist()
 
 
-class SparseDrugCombo(MCMCModel):
+class SparseDrugCombo(BayesianModel, HomoscedasticModel, MCMCModel):
     def __init__(
         self,
         n_embedding_dimensions: int,  # embedding dimension

--- a/src/batchie/models/sparse_combo.py
+++ b/src/batchie/models/sparse_combo.py
@@ -8,7 +8,7 @@ import numpy as np
 from numpy.random import Generator
 from scipy.special import logit, expit
 
-from batchie.core import MCMCModel, Theta, ThetaHolder
+from batchie.core import HomoscedasticBayesianModel, MCMCModel, Theta, ThetaHolder
 from batchie.data import ScreenBase
 from batchie.fast_mvn import sample_mvn_from_precision
 from batchie.common import (

--- a/src/batchie/models/sparse_combo_interaction.py
+++ b/src/batchie/models/sparse_combo_interaction.py
@@ -14,7 +14,13 @@ from batchie.common import (
     CONTROL_SENTINEL_VALUE,
     copy_array_with_control_treatments_set_to_zero,
 )
-from batchie.core import MCMCModel, Theta, ThetaHolder
+from batchie.core import (
+    BayesianModel,
+    HomoscedasticModel,
+    MCMCModel,
+    Theta,
+    ThetaHolder,
+)
 from batchie.data import ScreenBase, create_single_treatment_effect_map
 from batchie.fast_mvn import sample_mvn_from_precision
 from dataclasses import dataclass
@@ -424,7 +430,7 @@ class LegacySparseDrugComboInteractionImpl:
         return Mu
 
 
-class SparseDrugComboInteraction(MCMCModel):
+class SparseDrugComboInteraction(BayesianModel, HomoscedasticModel, MCMCModel):
     def __init__(
         self,
         n_embedding_dimensions: int,  # embedding dimension

--- a/src/batchie/retrospective.py
+++ b/src/batchie/retrospective.py
@@ -231,9 +231,9 @@ class PairwisePlateGenerator(RetrospectivePlateGenerator):
                 eligible_plate_names, size=n_to_assign, replace=True
             )
 
-            new_plate_names[
-                single_treatment_screen.sample_names == sample_name
-            ] = assignments
+            new_plate_names[single_treatment_screen.sample_names == sample_name] = (
+                assignments
+            )
 
         single_screen_with_generated_plates = Screen(
             treatment_names=single_treatment_screen.treatment_names,

--- a/src/batchie/sampling.py
+++ b/src/batchie/sampling.py
@@ -3,13 +3,13 @@ import logging
 import numpy.random
 from tqdm import trange
 
-from batchie.core import BayesianModel, ThetaHolder, MCMCModel, VIModel
+from batchie.core import ThetaHolder, MCMCModel, VIModel
 
 logger = logging.getLogger(__name__)
 
 
 def sample(
-    model: BayesianModel,
+    model,
     results: ThetaHolder,
     seed: int,
     n_chains: int = None,
@@ -31,46 +31,45 @@ def sample(
     :param progress_bar: Whether to display a progress bar
     :return: a :py:class:`ThetaHolder` containing the sampled parameters
     """
+    match model:
+        case MCMCModel():
+            if n_chains is None:
+                raise ValueError("n_chains must be set when model is MCMCModel")
+            if chain_index is None:
+                raise ValueError("chain_index must be set when model is MCMCModel")
+            if n_burnin is None:
+                raise ValueError("n_burnin must be set when model is MCMCModel")
+            if thin is None:
+                raise ValueError("thin must be set when model is MCMCModel")
 
-    if isinstance(model, MCMCModel):
-        if n_chains is None:
-            raise ValueError("n_chains must be set when model is MCMCModel")
-        if chain_index is None:
-            raise ValueError("chain_index must be set when model is MCMCModel")
-        if n_burnin is None:
-            raise ValueError("n_burnin must be set when model is MCMCModel")
-        if thin is None:
-            raise ValueError("thin must be set when model is MCMCModel")
+            seeds = numpy.random.SeedSequence(seed).spawn(n_chains)
+            rng = numpy.random.default_rng(seeds[chain_index])
 
-        seeds = numpy.random.SeedSequence(seed).spawn(n_chains)
-        rng = numpy.random.default_rng(seeds[chain_index])
+            model.reset_model()
+            model.set_rng(rng)
 
-        model.reset_model()
-        model.set_rng(rng)
-
-        logger.info(
-            "Will run {} total iterations on model {}".format(
-                results.n_thetas * thin + n_burnin, model
+            logger.info(
+                "Will run {} total iterations on model {}".format(
+                    results.n_thetas * thin + n_burnin, model
+                )
             )
-        )
 
-        for _ in trange(n_burnin, disable=not progress_bar):
-            model.step()
+            for _ in trange(n_burnin, disable=not progress_bar):
+                model.step()
 
-        total_steps = results.n_thetas * thin
-        for step_index in trange(total_steps, disable=not progress_bar):
-            model.step()
-            if ((step_index + 1) % thin) == 0:
-                results.add_theta(model.get_model_state())
-
-    elif isinstance(model, VIModel):
-        model.reset_model()
-        rng = numpy.random.default_rng(seed)
-        model.set_rng(rng)
-        samples = model.sample(num_samples=results.n_thetas)
-        for theta in samples:
-            results.add_theta(theta)
-    else:
-        raise ValueError("model must be one of MCMCModel, VIModel")
+            total_steps = results.n_thetas * thin
+            for step_index in trange(total_steps, disable=not progress_bar):
+                model.step()
+                if ((step_index + 1) % thin) == 0:
+                    results.add_theta(model.get_model_state())
+        case VIModel():
+            model.reset_model()
+            rng = numpy.random.default_rng(seed)
+            model.set_rng(rng)
+            samples = model.sample(num_samples=results.n_thetas)
+            for theta in samples:
+                results.add_theta(theta)
+        case other:
+            raise ValueError(f"model must be one of MCMCModel, VIModel, got {other}")
 
     return results

--- a/src/batchie/sampling_test.py
+++ b/src/batchie/sampling_test.py
@@ -1,9 +1,12 @@
 import batchie.sampling
-from batchie.core import MCMCModel, ThetaHolder
+from batchie.core import BayesianModel, VIModel, MCMCModel, ThetaHolder
 
 
-def test_sample(mocker):
-    fake_model = mocker.MagicMock(spec=MCMCModel)
+def test_sample_mcmc(mocker):
+    class M(BayesianModel, MCMCModel):
+        pass
+
+    fake_model = mocker.Mock(spec=M)
     fake_results_holder = mocker.MagicMock(spec=ThetaHolder)
 
     fake_results_holder.n_thetas = 10
@@ -20,4 +23,29 @@ def test_sample(mocker):
     )
 
     assert fake_model.step.call_count == 30
+    assert fake_results_holder.add_theta.call_count == 10
+
+
+def test_sample_vi(mocker):
+    class M(BayesianModel, VIModel):
+        pass
+
+    fake_model = mocker.Mock(spec=M)
+    fake_model.sample.return_value = list(range(10))
+    fake_results_holder = mocker.MagicMock(spec=ThetaHolder)
+
+    fake_results_holder.n_thetas = 10
+
+    batchie.sampling.sample(
+        model=fake_model,
+        results=fake_results_holder,
+        seed=0,
+        n_chains=1,
+        chain_index=0,
+        n_burnin=10,
+        thin=2,
+        progress_bar=False,
+    )
+
+    assert fake_model.sample.call_count == 1
     assert fake_results_holder.add_theta.call_count == 10

--- a/src/batchie/scoring/rand.py
+++ b/src/batchie/scoring/rand.py
@@ -10,7 +10,6 @@ from batchie.distance_calculation import ChunkedDistanceMatrix
 
 
 class RandomScorer(Scorer):
-
     """
     A scorer that returns a random score for each plate, used for baseline comparison
     """


### PR DESCRIPTION
- Create separate methods for hetero vs homoscedastic methods
- Use mixin classes and multiple inheritance instead of methods with Union types
- Prefer pattern matching to distinguish model type specific branches (instead of isinstance)
- Fix integration tests