### PR TITLE
Move Prediction to Theta, Avoid Per Model Implementation of Theta Holder

### DIFF
--- a/perf/legacy_sparse_combo_model/legacy_sparse_combo_model.py
+++ b/perf/legacy_sparse_combo_model/legacy_sparse_combo_model.py
@@ -78,7 +78,7 @@ def run_benchmark():
         progress_bar=True,
     )
 
-    mse = calculate_mse(model=model, observed_screen=data, thetas=res)
+    mse = calculate_mse(observed_screen=data, thetas=res)
 
     print(mse)
     print(res.get_theta(0))

--- a/perf/sparse_combo_model/sparse_combo_model.py
+++ b/perf/sparse_combo_model/sparse_combo_model.py
@@ -75,7 +75,7 @@ def run_benchmark():
         progress_bar=True,
     )
 
-    mse = calculate_mse(model=model, observed_screen=data, thetas=res)
+    mse = calculate_mse(observed_screen=data, thetas=res)
 
     print(mse)
     print(res.get_theta(0))

--- a/src/batchie/cli/analyze_model_evaluation.py
+++ b/src/batchie/cli/analyze_model_evaluation.py
@@ -8,7 +8,7 @@ from batchie.cli.argument_parsing import KVAppendAction, cast_dict_to_type
 from batchie.common import N_UNIQUE_SAMPLES, N_UNIQUE_TREATMENTS
 from batchie.core import BayesianModel, ThetaHolder
 from batchie.data import Screen
-from batchie.models.main import predict_all, ModelEvaluation, correlation_matrix
+from batchie.models.main import ModelEvaluation, correlation_matrix
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +101,7 @@ def main():
 
     model.add_observations(screen.subset_observed())
 
-    theta_holder: ThetaHolder = model.get_results_holder(n_samples=1)
+    theta_holder: ThetaHolder = ThetaHolder(n_samples=1)
 
     theta_holders = [theta_holder.load_h5(x) for x in args.thetas]
 
@@ -113,7 +113,7 @@ def main():
 
     logger.info("Calculating correlation matrix")
 
-    corr = correlation_matrix(model, screen, thetas)
+    corr = correlation_matrix(screen, thetas)
 
     logger.info("Creating plots")
 

--- a/src/batchie/cli/analyze_model_evaluation.py
+++ b/src/batchie/cli/analyze_model_evaluation.py
@@ -101,7 +101,7 @@ def main():
 
     model.add_observations(screen.subset_observed())
 
-    theta_holder: ThetaHolder = ThetaHolder(n_samples=1)
+    theta_holder: ThetaHolder = ThetaHolder(n_thetas=1)
 
     theta_holders = [theta_holder.load_h5(x) for x in args.thetas]
 

--- a/src/batchie/cli/analyze_model_evaluation_test.py
+++ b/src/batchie/cli/analyze_model_evaluation_test.py
@@ -5,10 +5,11 @@ import tempfile
 import numpy as np
 import pytest
 
+from batchie.core import ThetaHolder
 from batchie.cli import analyze_model_evaluation
 from batchie.data import Screen
 from batchie.models.main import ModelEvaluation
-from batchie.models.sparse_combo import SparseDrugComboResults
+from batchie.models.sparse_combo import SparseDrugComboMCMCSample
 
 
 @pytest.fixture
@@ -49,14 +50,18 @@ def test_main(mocker, dataset):
     dataset.save_h5(os.path.join(tmpdir, "screen.h5"))
 
     n_thetas = 10
-    results_holder = SparseDrugComboResults(
-        n_thetas=n_thetas,
-        n_unique_samples=dataset.n_unique_samples,
-        n_unique_treatments=dataset.n_unique_treatments,
-        n_embedding_dimensions=5,
-    )
-
-    results_holder._cursor = n_thetas
+    results_holder = ThetaHolder(n_thetas=n_thetas)
+    for _ in range(n_thetas):
+        theta = SparseDrugComboMCMCSample(
+            W=np.zeros((5, 5)),
+            W0=np.zeros((5,)),
+            V2=np.zeros((10, 5)),
+            V1=np.zeros((10, 5)),
+            V0=np.zeros((10,)),
+            alpha=5.0,
+            precision=100.0,
+        )
+        results_holder.add_theta(theta)
 
     results_holder.save_h5(os.path.join(tmpdir, "samples.h5"))
 

--- a/src/batchie/cli/calculate_distance_matrix.py
+++ b/src/batchie/cli/calculate_distance_matrix.py
@@ -125,7 +125,7 @@ def main():
 
     model.add_observations(data.subset_observed())
 
-    thetas_holder: ThetaHolder = ThetaHolder(n_samples=1)
+    thetas_holder: ThetaHolder = ThetaHolder(n_thetas=1)
 
     thetas = thetas_holder.concat([thetas_holder.load_h5(x) for x in args.thetas])
 

--- a/src/batchie/cli/calculate_distance_matrix.py
+++ b/src/batchie/cli/calculate_distance_matrix.py
@@ -125,7 +125,7 @@ def main():
 
     model.add_observations(data.subset_observed())
 
-    thetas_holder: ThetaHolder = model.get_results_holder(n_samples=1)
+    thetas_holder: ThetaHolder = ThetaHolder(n_samples=1)
 
     thetas = thetas_holder.concat([thetas_holder.load_h5(x) for x in args.thetas])
 

--- a/src/batchie/cli/calculate_distance_matrix_test.py
+++ b/src/batchie/cli/calculate_distance_matrix_test.py
@@ -1,10 +1,11 @@
 import os.path
 import shutil
 import tempfile
-
+import numpy as np
 from batchie.cli import calculate_distance_matrix
 from batchie.distance_calculation import ChunkedDistanceMatrix
-from batchie.models.sparse_combo import SparseDrugComboResults
+from batchie.models.sparse_combo import SparseDrugComboMCMCSample
+from batchie.core import ThetaHolder
 
 
 def test_main_complete(mocker, test_combo_dataset):
@@ -30,14 +31,20 @@ def test_main_complete(mocker, test_combo_dataset):
     ]
 
     test_combo_dataset.save_h5(os.path.join(tmpdir, "data.h5"))
-    results_holder = SparseDrugComboResults(
-        n_thetas=10,
-        n_unique_samples=test_combo_dataset.n_unique_samples,
-        n_unique_treatments=test_combo_dataset.n_unique_treatments,
-        n_embedding_dimensions=5,
-    )
 
-    results_holder._cursor = 10
+    n_thetas = 10
+    results_holder = ThetaHolder(n_thetas=n_thetas)
+    for _ in range(n_thetas):
+        theta = SparseDrugComboMCMCSample(
+            W=np.zeros((5, 5)),
+            W0=np.zeros((5,)),
+            V2=np.zeros((10, 5)),
+            V1=np.zeros((10, 5)),
+            V0=np.zeros((10,)),
+            alpha=5.0,
+            precision=100.0,
+        )
+        results_holder.add_theta(theta)
 
     results_holder.save_h5(os.path.join(tmpdir, "samples.h5"))
 
@@ -76,14 +83,20 @@ def test_main_partial(mocker, test_combo_dataset):
         ]
 
         test_combo_dataset.save_h5(os.path.join(tmpdir, "data.h5"))
-        results_holder = SparseDrugComboResults(
-            n_thetas=10,
-            n_unique_samples=test_combo_dataset.n_unique_samples,
-            n_unique_treatments=test_combo_dataset.n_unique_treatments,
-            n_embedding_dimensions=5,
-        )
 
-        results_holder._cursor = 10
+        n_thetas = 10
+        results_holder = ThetaHolder(n_thetas=n_thetas)
+        for _ in range(n_thetas):
+            theta = SparseDrugComboMCMCSample(
+                W=np.zeros((5, 5)),
+                W0=np.zeros((5,)),
+                V2=np.zeros((10, 5)),
+                V1=np.zeros((10, 5)),
+                V0=np.zeros((10,)),
+                alpha=5.0,
+                precision=100.0,
+            )
+            results_holder.add_theta(theta)
 
         results_holder.save_h5(os.path.join(tmpdir, "samples.h5"))
 

--- a/src/batchie/cli/calculate_scores.py
+++ b/src/batchie/cli/calculate_scores.py
@@ -148,7 +148,7 @@ def main():
 
     scorer: Scorer = args.scorer_cls(**args.scorer_params)
 
-    thetas_holder: ThetaHolder = model.get_results_holder(n_samples=1)
+    thetas_holder: ThetaHolder = ThetaHolder(n_samples=1)
 
     thetas = thetas_holder.concat([thetas_holder.load_h5(x) for x in args.thetas])
 

--- a/src/batchie/cli/calculate_scores.py
+++ b/src/batchie/cli/calculate_scores.py
@@ -148,7 +148,7 @@ def main():
 
     scorer: Scorer = args.scorer_cls(**args.scorer_params)
 
-    thetas_holder: ThetaHolder = ThetaHolder(n_samples=1)
+    thetas_holder: ThetaHolder = ThetaHolder(n_thetas=1)
 
     thetas = thetas_holder.concat([thetas_holder.load_h5(x) for x in args.thetas])
 

--- a/src/batchie/cli/calculate_scores_test.py
+++ b/src/batchie/cli/calculate_scores_test.py
@@ -8,8 +8,9 @@ import pytest
 from batchie.cli import calculate_scores
 from batchie.data import Screen
 from batchie.distance_calculation import ChunkedDistanceMatrix
-from batchie.models.sparse_combo import SparseDrugComboResults
+from batchie.models.sparse_combo import SparseDrugComboMCMCSample
 from batchie.scoring.main import ChunkedScoresHolder
+from batchie.core import ThetaHolder
 
 
 @pytest.fixture
@@ -66,14 +67,19 @@ def test_main(mocker, test_dataset, test_dist_matrix):
     ]
 
     test_dataset.save_h5(os.path.join(tmpdir, "data.h5"))
-    results_holder = SparseDrugComboResults(
-        n_thetas=10,
-        n_unique_samples=test_dataset.n_unique_samples,
-        n_unique_treatments=test_dataset.n_unique_treatments,
-        n_embedding_dimensions=5,
-    )
-
-    results_holder._cursor = 10
+    n_thetas = 10
+    results_holder = ThetaHolder(n_thetas=n_thetas)
+    for _ in range(n_thetas):
+        theta = SparseDrugComboMCMCSample(
+            W=np.zeros((5, 5)),
+            W0=np.zeros((5,)),
+            V2=np.zeros((10, 5)),
+            V1=np.zeros((10, 5)),
+            V0=np.zeros((10,)),
+            alpha=5.0,
+            precision=100.0,
+        )
+        results_holder.add_theta(theta)
 
     results_holder.save_h5(os.path.join(tmpdir, "samples.h5"))
 
@@ -115,14 +121,19 @@ def test_main_exclude(mocker, test_dataset, test_dist_matrix):
     ]
 
     test_dataset.save_h5(os.path.join(tmpdir, "data.h5"))
-    results_holder = SparseDrugComboResults(
-        n_thetas=10,
-        n_unique_samples=test_dataset.n_unique_samples,
-        n_unique_treatments=test_dataset.n_unique_treatments,
-        n_embedding_dimensions=5,
-    )
-
-    results_holder._cursor = 10
+    n_thetas = 10
+    results_holder = ThetaHolder(n_thetas=n_thetas)
+    for _ in range(n_thetas):
+        theta = SparseDrugComboMCMCSample(
+            W=np.zeros((5, 5)),
+            W0=np.zeros((5,)),
+            V2=np.zeros((10, 5)),
+            V1=np.zeros((10, 5)),
+            V0=np.zeros((10,)),
+            alpha=5.0,
+            precision=100.0,
+        )
+        results_holder.add_theta(theta)
 
     results_holder.save_h5(os.path.join(tmpdir, "samples.h5"))
 

--- a/src/batchie/cli/evaluate_model.py
+++ b/src/batchie/cli/evaluate_model.py
@@ -92,7 +92,7 @@ def main():
 
     model: BayesianModel = args.model_cls(**args.model_params)
 
-    theta_holder: ThetaHolder = ThetaHolder(n_samples=1)
+    theta_holder: ThetaHolder = ThetaHolder(n_thetas=1)
 
     theta_holders = [theta_holder.load_h5(x) for x in args.thetas]
 

--- a/src/batchie/cli/evaluate_model.py
+++ b/src/batchie/cli/evaluate_model.py
@@ -9,7 +9,7 @@ from batchie.cli.argument_parsing import KVAppendAction, cast_dict_to_type
 from batchie.common import N_UNIQUE_SAMPLES, N_UNIQUE_TREATMENTS
 from batchie.core import BayesianModel, ThetaHolder
 from batchie.data import Screen
-from batchie.models.main import predict_all, ModelEvaluation
+from batchie.models.main import predict_viability_all, ModelEvaluation
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +92,7 @@ def main():
 
     model: BayesianModel = args.model_cls(**args.model_params)
 
-    theta_holder: ThetaHolder = model.get_results_holder(n_samples=1)
+    theta_holder: ThetaHolder = ThetaHolder(n_samples=1)
 
     theta_holders = [theta_holder.load_h5(x) for x in args.thetas]
 
@@ -104,7 +104,7 @@ def main():
 
     chain_ids = np.array(chain_ids, dtype=int)
 
-    predictions = predict_all(
+    predictions = predict_viability_all(
         screen=screen,
         thetas=thetas,
         model=model,

--- a/src/batchie/cli/evaluate_model.py
+++ b/src/batchie/cli/evaluate_model.py
@@ -107,7 +107,6 @@ def main():
     predictions = predict_viability_all(
         screen=screen,
         thetas=thetas,
-        model=model,
     ).T
 
     me = ModelEvaluation(

--- a/src/batchie/cli/evaluate_model_test.py
+++ b/src/batchie/cli/evaluate_model_test.py
@@ -8,7 +8,8 @@ import pytest
 from batchie.cli import evaluate_model
 from batchie.data import Screen
 from batchie.models.main import ModelEvaluation
-from batchie.models.sparse_combo import SparseDrugComboResults
+from batchie.models.sparse_combo import SparseDrugComboMCMCSample
+from batchie.core import ThetaHolder
 
 
 @pytest.fixture
@@ -64,15 +65,18 @@ def test_main(mocker, training_dataset, test_dataset):
     test_dataset.save_h5(os.path.join(tmpdir, "test.screen.h5"))
 
     n_thetas = 10
-    results_holder = SparseDrugComboResults(
-        n_thetas=n_thetas,
-        n_unique_samples=training_dataset.n_unique_samples,
-        n_unique_treatments=training_dataset.n_unique_treatments,
-        n_embedding_dimensions=5,
-    )
-
-    results_holder._cursor = n_thetas
-
+    results_holder = ThetaHolder(n_thetas=n_thetas)
+    for _ in range(n_thetas):
+        theta = SparseDrugComboMCMCSample(
+            W=np.zeros((5, 5)),
+            W0=np.zeros((5,)),
+            V2=np.zeros((10, 5)),
+            V1=np.zeros((10, 5)),
+            V0=np.zeros((10,)),
+            alpha=5.0,
+            precision=100.0,
+        )
+        results_holder.add_theta(theta)
     results_holder.save_h5(os.path.join(tmpdir, "samples.h5"))
 
     mocker.patch("sys.argv", command_line_args)

--- a/src/batchie/cli/train_model.py
+++ b/src/batchie/cli/train_model.py
@@ -117,7 +117,7 @@ def main():
 
     model: BayesianModel = args.model_cls(**args.model_params)
 
-    samples_holder: ThetaHolder = model.get_results_holder(n_samples=args.n_samples)
+    samples_holder: ThetaHolder = ThetaHolder(n_samples=args.n_samples)
 
     observed_subset = data.subset_observed()
 

--- a/src/batchie/cli/train_model.py
+++ b/src/batchie/cli/train_model.py
@@ -117,7 +117,7 @@ def main():
 
     model: BayesianModel = args.model_cls(**args.model_params)
 
-    samples_holder: ThetaHolder = ThetaHolder(n_samples=args.n_samples)
+    samples_holder: ThetaHolder = ThetaHolder(n_thetas=args.n_samples)
 
     observed_subset = data.subset_observed()
 

--- a/src/batchie/cli/train_model_test.py
+++ b/src/batchie/cli/train_model_test.py
@@ -3,7 +3,7 @@ import shutil
 import tempfile
 
 from batchie.cli import train_model
-from batchie.models.sparse_combo import SparseDrugComboResults
+from batchie.core import ThetaHolder
 
 
 def test_main(mocker, test_combo_dataset):
@@ -30,7 +30,7 @@ def test_main(mocker, test_combo_dataset):
     mocker.patch("sys.argv", command_line_args)
     try:
         train_model.main()
-        results = SparseDrugComboResults.load_h5(os.path.join(tmpdir, "samples.h5"))
+        results = ThetaHolder.load_h5(os.path.join(tmpdir, "samples.h5"))
         assert results.n_thetas == 1
 
     finally:

--- a/src/batchie/common.py
+++ b/src/batchie/common.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-ArrayType = np.array
+ArrayType = np.ndarray
 FloatingPointType = float
 
 CONTROL_SENTINEL_VALUE = -1

--- a/src/batchie/core.py
+++ b/src/batchie/core.py
@@ -29,7 +29,7 @@ class Theta:
         raise NotImplementedError
 
     @abstractmethod
-    def predict_mean(self, data: ScreenBase) -> ArrayType:
+    def predict_conditional_mean(self, data: ScreenBase) -> ArrayType:
         """
         Predict the conditional mean of an :py:class:`batchie.data.ExperimentBase` in modeling space.
 
@@ -38,7 +38,7 @@ class Theta:
         raise NotImplementedError
 
     @abstractmethod
-    def predict_variance(self, data: ScreenBase) -> ArrayType:
+    def predict_conditional_variance(self, data: ScreenBase) -> ArrayType:
         """
         Predict the conditional variance of an :py:class:`batchie.data.ExperimentBase`.
 

--- a/src/batchie/core.py
+++ b/src/batchie/core.py
@@ -73,6 +73,29 @@ class Theta:
         """
         raise NotImplementedError
 
+    def equals(self, other):
+        print("fsdsdfsd")
+        if not isinstance(other, type(self)):
+            return False
+
+        for d1, d2 in [
+            (self.private_parameters_dict(), other.private_parameters_dict()),
+            (self.shared_parameters_dict(), other.shared_parameters_dict()),
+        ]:
+            for k, v in d1.items():
+                if k not in d2:
+                    return False
+                if isinstance(v, Number):
+                    if v != d2[k]:
+                        return False
+                elif isinstance(v, ArrayType):
+                    if not np.array_equal(v, d2[k]):
+                        return False
+                else:
+                    if v != d2[k]:
+                        return False
+        return True
+
 
 class ThetaHolder(ABC):
     """
@@ -207,8 +230,8 @@ class ThetaHolder(ABC):
         return self._n_thetas
 
     def __iter__(self):
-        for i in range(self.n_thetas):
-            yield self.get_theta(i)
+        for theta in self.thetas:
+            yield theta
 
     @property
     def is_complete(self):
@@ -320,18 +343,18 @@ class BayesianModel(ABC):
         """
         raise NotImplementedError
 
-
-class MCMCModel:
-    """
-    This class subclasses BayesianModel and implements :py:meth:`batchie.core.MCMCModel.step`
-    """
-
     @abstractmethod
     def reset_model(self):
         """
         Reset the internal state of the model to its initial state.
         """
         raise NotImplementedError
+
+
+class MCMCModel:
+    """
+    This class subclasses BayesianModel and implements :py:meth:`batchie.core.MCMCModel.step`
+    """
 
     @abstractmethod
     def get_model_state(self) -> Theta:

--- a/src/batchie/core_test.py
+++ b/src/batchie/core_test.py
@@ -47,9 +47,21 @@ def test_samples_holder():
 
 
 def test_samples_holder_concat():
-    holder = ThetaHolder.concat([ThetaHolder(3), ThetaHolder(3)])
+    holder = ThetaHolder(3)
 
-    assert len(list(holder)) == 6
+    for i in range(3):
+        sample = TestBayesianModelParamsImpl(W=np.ones((2, 2)) * i)
+        holder.add_theta(sample)
+
+    holder2 = ThetaHolder(3)
+
+    for i in range(3):
+        sample = TestBayesianModelParamsImpl(W=np.ones((2, 2)) * i)
+        holder2.add_theta(sample)
+
+    holder3 = ThetaHolder.concat([holder, holder2])
+
+    assert len(list(holder3)) == 6
 
 
 @pytest.fixture

--- a/src/batchie/distance_calculation.py
+++ b/src/batchie/distance_calculation.py
@@ -242,7 +242,7 @@ def calculate_pairwise_distance_matrix_on_predictions(
     progress: bool = False,
 ) -> ChunkedDistanceMatrix:
     """
-    Calculate the pairwise distance matrix between predictions.
+    Calculate the pairwise distance matrix between predictions in viability space.
 
     For all pairs of thetas in the given :py:class:`ThetaHolder`, predictions will be made on the unobserved
     conditions in the given :py:class:`Experiment` and the distance between the predictions produced by the two
@@ -272,12 +272,10 @@ def calculate_pairwise_distance_matrix_on_predictions(
 
     for i, j in tqdm.tqdm(indices) if progress else indices:
         sample_i = thetas.get_theta(i)
-        model.set_model_state(sample_i)
-        i_pred = model.predict(data)
+        i_pred = sample_i.predict_viability(data)
 
         sample_j = thetas.get_theta(j)
-        model.set_model_state(sample_j)
-        j_pred = model.predict(data)
+        j_pred = sample_j.predict_viability(data)
 
         value = distance_metric.distance(i_pred, j_pred)
 

--- a/src/batchie/models/grid_combo.py
+++ b/src/batchie/models/grid_combo.py
@@ -103,11 +103,11 @@ class GridComboSample(Theta):
         return result
 
     def predict_viability(self, data: ScreenBase) -> ArrayType:
-        return self.predict_mean(
+        return self.predict_conditional_mean(
             data
         )  ## Probability space = viability space for this model
 
-    def predict_mean(self, data: ScreenBase) -> ArrayType:
+    def predict_conditional_mean(self, data: ScreenBase) -> ArrayType:
         sample_ids, drug_ids_1, drug_ids_2, log_conc1, log_conc2 = unpack_data(
             data=data, drugname2idx=self.drugname2idx, use_mask=False
         )
@@ -173,7 +173,7 @@ class GridComboSample(Theta):
         mu = mu.detach().numpy()
         return mu
 
-    def predict_variance(self, data: ScreenBase) -> ArrayType:
+    def predict_conditional_variance(self, data: ScreenBase) -> ArrayType:
         sample_ids, drug_ids_1, drug_ids_2, log_conc1, log_conc2 = unpack_data(
             data=data, drugname2idx=self.drugname2idx, use_mask=False
         )
@@ -187,7 +187,7 @@ class GridComboSample(Theta):
         log_conc2 = torch.from_numpy(log_conc2).float()
         log_conc2 = torch.nan_to_num(log_conc2)  ## Just 0 out the nans
 
-        mu = torch.from_numpy(self.predict_mean(data)).float()
+        mu = torch.from_numpy(self.predict_conditional_mean(data)).float()
 
         n_data = sample_ids.shape[0]
 

--- a/src/batchie/models/main.py
+++ b/src/batchie/models/main.py
@@ -180,7 +180,7 @@ def predict_mean_all(screen: ScreenBase, thetas: ThetaHolder):
     result = np.zeros((thetas.n_thetas, screen.size), dtype=FloatingPointType)
     for theta_index in range(thetas.n_thetas):
         theta = thetas.get_theta(theta_index)
-        result[theta_index, :] = theta.predict_mean(screen)
+        result[theta_index, :] = theta.predict_conditional_mean(screen)
 
         if np.isnan(result[theta_index, :]).any():
             raise ValueError(
@@ -204,7 +204,7 @@ def predict_variance_all(screen: ScreenBase, thetas: ThetaHolder):
     results = []
     for theta_index in range(thetas.n_thetas):
         theta = thetas.get_theta(theta_index)
-        result = theta.predict_variance(screen)
+        result = theta.predict_conditional_variance(screen)
 
         if not result.size == screen.size:
             raise ValueError(
@@ -234,7 +234,7 @@ def predict_mean_avg(screen: ScreenBase, thetas: ThetaHolder):
     for theta_index in range(thetas.n_thetas):
         theta = thetas.get_theta(theta_index)
 
-        sub_result = theta.predict_mean(screen)
+        sub_result = theta.predict_conditional_mean(screen)
 
         if np.isnan(sub_result).any():
             raise ValueError(

--- a/src/batchie/models/main.py
+++ b/src/batchie/models/main.py
@@ -331,7 +331,7 @@ def correlation_matrix(screen: ScreenBase, thetas: ThetaHolder):
     for sample_id in screen.unique_sample_ids:
         combinatoric_space = generate_full_combinatoric_space(sample_id, screen)
 
-        predictions.append(predict_mean_avg(combinatoric_space, thetas))
+        predictions.append(predict_viability_avg(combinatoric_space, thetas))
         index.append(id_to_name[sample_id])
 
     predictions = np.stack(predictions)

--- a/src/batchie/models/main_test.py
+++ b/src/batchie/models/main_test.py
@@ -155,14 +155,15 @@ def test_predict_all(mocker, screen):
 
 
 def test_predict_avg(mocker, screen):
-    model = mocker.MagicMock(spec=BayesianModel)
-    thetas = mocker.MagicMock(spec=ThetaHolder)
+    theta = mocker.MagicMock(spec=Theta)
+    theta.predict_viability.return_value = np.ones(
+        (screen.size,), dtype=FloatingPointType
+    )
+    thetas = ThetaHolder(5)
+    for _ in range(5):
+        thetas.add_theta(theta)
 
-    thetas.n_thetas = 5
-
-    model.predict.return_value = np.ones((screen.size,), dtype=FloatingPointType)
-
-    result = main.predict_avg(model, screen, thetas)
+    result = main.predict_viability_avg(screen, thetas)
 
     assert result.shape == (6,)
 

--- a/src/batchie/models/sparse_combo.py
+++ b/src/batchie/models/sparse_combo.py
@@ -632,8 +632,6 @@ class SparseDrugCombo(BayesianModel, MCMCModel):
             W=self.wrapped_model.W.copy().astype(FloatingPointType),
             V2=self.wrapped_model.V2.copy().astype(FloatingPointType),
             V1=self.wrapped_model.V1.copy().astype(FloatingPointType),
-            predict_interactions=self.predict_interactions,
-            interaction_log_transform=self.interaction_log_transform,
         )
 
     def step(self):

--- a/src/batchie/models/sparse_combo.py
+++ b/src/batchie/models/sparse_combo.py
@@ -35,8 +35,6 @@ class SparseDrugComboMCMCSample(Theta):
     V0: ArrayType
     alpha: float
     precision: float
-    predict_interactions: bool
-    interaction_log_transform: bool
 
     def predict_viability(self, data: ScreenBase) -> ArrayType:
         if data.treatment_arity == 1:

--- a/src/batchie/models/sparse_combo.py
+++ b/src/batchie/models/sparse_combo.py
@@ -50,7 +50,7 @@ class SparseDrugComboMCMCSample(Theta):
         else:
             raise NotImplementedError("SparseDrugCombo only supports 1 or 2 treatments")
 
-    def predict_mean(self, data: ScreenBase) -> ArrayType:
+    def predict_conditional_mean(self, data: ScreenBase) -> ArrayType:
         if data.treatment_arity == 1:
             return predict_single_drug(self, data, viability=False)
         elif data.treatment_arity == 2:
@@ -58,7 +58,7 @@ class SparseDrugComboMCMCSample(Theta):
         else:
             raise NotImplementedError("SparseDrugCombo only supports 1 or 2 treatments")
 
-    def predict_variance(self, data: ScreenBase) -> ArrayType:
+    def predict_conditional_variance(self, data: ScreenBase) -> ArrayType:
         v = np.repeat(1 / self.precision, repeats=data.size)
         return v
 

--- a/src/batchie/models/sparse_combo.py
+++ b/src/batchie/models/sparse_combo.py
@@ -21,8 +21,6 @@ from batchie.common import (
     FloatingPointType,
 )
 
-from common import ArrayType
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/batchie/models/sparse_combo.py
+++ b/src/batchie/models/sparse_combo.py
@@ -23,6 +23,8 @@ from batchie.common import (
     FloatingPointType,
 )
 
+from common import ArrayType
+
 logger = logging.getLogger(__name__)
 
 
@@ -37,145 +39,35 @@ class SparseDrugComboMCMCSample(Theta):
     V0: ArrayType
     alpha: float
     precision: float
+    predict_interactions: bool
+    interaction_log_transform: bool
 
+    def predict_viability(self, data: ScreenBase) -> ArrayType:
+        if data.treatment_arity == 1:
+            return predict_single_drug(self, data, viability=True)
+        elif data.treatment_arity == 2:
+            return predict(self, data, viability=True)
+        else:
+            raise NotImplementedError("SparseDrugCombo only supports 1 or 2 treatments")
 
-class SparseDrugComboResults(ThetaHolder):
-    def __init__(
-        self,
-        n_unique_samples: int,
-        n_unique_treatments: int,
-        n_embedding_dimensions: int,
-        n_thetas: int,
-    ):
-        super().__init__(n_thetas)
-        self.n_unique_samples = n_unique_samples
-        self.n_unique_treatments = n_unique_treatments
-        self.n_embedding_dimensions = n_embedding_dimensions
+    def predict_mean(self, data: ScreenBase) -> ArrayType:
+        if data.treatment_arity == 1:
+            return predict_single_drug(self, data, viability=False)
+        elif data.treatment_arity == 2:
+            return predict(self, data, viability=False)
+        else:
+            raise NotImplementedError("SparseDrugCombo only supports 1 or 2 treatments")
 
-        self.V2 = np.zeros(
-            (n_thetas, self.n_unique_treatments, self.n_embedding_dimensions),
-            dtype=FloatingPointType,
-        )
-        self.V1 = np.zeros(
-            (n_thetas, self.n_unique_treatments, self.n_embedding_dimensions),
-            dtype=FloatingPointType,
-        )
-        self.W = np.zeros(
-            (n_thetas, self.n_unique_samples, self.n_embedding_dimensions),
-            dtype=FloatingPointType,
-        )
-        self.V0 = np.zeros(
-            (
-                n_thetas,
-                self.n_unique_treatments,
-            ),
-            FloatingPointType,
-        )
-        self.W0 = np.zeros(
-            (
-                n_thetas,
-                self.n_unique_samples,
-            ),
-            FloatingPointType,
-        )
+    def predict_variance(self, data: ScreenBase) -> ArrayType:
+        v = np.repeat(1 / self.precision, repeats=data.size)
+        return v
 
-        self.alpha = np.zeros((n_thetas,), FloatingPointType)
-        self.precision = np.zeros((n_thetas,), FloatingPointType)
+    def private_parameters_dict(self) -> dict[str, ArrayType]:
+        return self.__dict__
 
-    def combine(self, other):
-        if type(self) != type(other):
-            raise ValueError("Cannot combine with different type")
-
-        if self.n_embedding_dimensions != other.n_embedding_dimensions:
-            raise ValueError("Cannot combine with different embedding dimensions")
-
-        if self.n_unique_samples != other.n_unique_samples:
-            raise ValueError("Cannot combine with different number of unique samples")
-
-        if self.n_unique_treatments != other.n_unique_treatments:
-            raise ValueError(
-                "Cannot combine with different number of unique treatments"
-            )
-
-        output = SparseDrugComboResults(
-            n_unique_samples=self.n_unique_samples,
-            n_unique_treatments=self.n_unique_treatments,
-            n_embedding_dimensions=self.n_embedding_dimensions,
-            n_thetas=self.n_thetas + other.n_thetas,
-        )
-
-        for i in range(self.n_thetas):
-            sample = self.get_theta(i)
-            output.add_theta(sample)
-
-        for i in range(other.n_thetas):
-            sample = other.get_theta(i)
-            output.add_theta(sample)
-
-        return output
-
-    def get_theta(self, step_index: int) -> SparseDrugComboMCMCSample:
-        # Test if this is beyond the step we are current at with the cursor
-        if step_index >= self._cursor:
-            raise ValueError("Cannot get a step beyond the current cursor position")
-
-        return SparseDrugComboMCMCSample(
-            W=self.W[step_index],
-            W0=self.W0[step_index],
-            V2=self.V2[step_index],
-            V1=self.V1[step_index],
-            V0=self.V0[step_index],
-            alpha=self.alpha[step_index].item(),
-            precision=self.precision[step_index].item(),
-        )
-
-    def _save_theta(self, sample: SparseDrugComboMCMCSample, sample_index: int):
-        self.V2[sample_index] = sample.V2
-        self.V1[sample_index] = sample.V1
-        self.W[sample_index] = sample.W
-        self.V0[sample_index] = sample.V0
-        self.W0[sample_index] = sample.W0
-        self.alpha[sample_index] = sample.alpha
-        self.precision[sample_index] = sample.precision
-
-    def save_h5(self, fn: str):
-        with h5py.File(fn, "w") as f:
-            f.create_dataset("V2", data=self.V2, compression="gzip")
-            f.create_dataset("V1", data=self.V1, compression="gzip")
-            f.create_dataset("W", data=self.W, compression="gzip")
-            f.create_dataset("V0", data=self.V0, compression="gzip")
-            f.create_dataset("W0", data=self.W0, compression="gzip")
-            f.create_dataset("alpha", data=self.alpha, compression="gzip")
-            f.create_dataset("precision", data=self.precision, compression="gzip")
-
-            # Save the cursor value metadata
-            f.attrs["cursor"] = self._cursor
-
-    @staticmethod
-    def load_h5(path: str):
-        with h5py.File(path, "r") as f:
-            n_unique_samples = f["W"].shape[1]
-            n_unique_treatments = f["V0"].shape[1]
-            n_embedding_dimensions = f["W"].shape[2]
-            n_samples = f["W"].shape[0]
-
-            results = SparseDrugComboResults(
-                n_unique_samples=n_unique_samples,
-                n_unique_treatments=n_unique_treatments,
-                n_embedding_dimensions=n_embedding_dimensions,
-                n_thetas=n_samples,
-            )
-
-            results.V2 = f["V2"][:]
-            results.V1 = f["V1"][:]
-            results.W = f["W"][:]
-            results.V0 = f["V0"][:]
-            results.W0 = f["W0"][:]
-            results.alpha = f["alpha"][:]
-            results.precision = f["precision"][:]
-            results._cursor = f.attrs["cursor"]
-
-        return results
+    @classmethod
+    def from_dicts(cls, private_params, shared_params):
+        return cls(**private_params)
 
 
 class LegacySparseDrugComboImpl:
@@ -737,17 +629,6 @@ class SparseDrugCombo(BayesianModel, HomoscedasticModel, MCMCModel):
             max_Mu=max_Mu,
         )
 
-    def set_model_state(self, theta: SparseDrugComboMCMCSample):
-        self.wrapped_model.reset_model()
-        self.wrapped_model.W0 = theta.W0.astype(np.float32)
-        self.wrapped_model.W = theta.W.astype(np.float32)
-        self.wrapped_model.V0 = theta.V0.astype(np.float32)
-        self.wrapped_model.V1 = theta.V1.astype(np.float32)
-        self.wrapped_model.V2 = theta.V2.astype(np.float32)
-        self.wrapped_model.alpha = theta.alpha
-        self.wrapped_model.prec = theta.precision
-        self.wrapped_model._reconstruct_Mu()
-
     def get_model_state(self) -> SparseDrugComboMCMCSample:
         return SparseDrugComboMCMCSample(
             precision=self.wrapped_model.prec,
@@ -757,32 +638,9 @@ class SparseDrugCombo(BayesianModel, HomoscedasticModel, MCMCModel):
             W=self.wrapped_model.W.copy().astype(FloatingPointType),
             V2=self.wrapped_model.V2.copy().astype(FloatingPointType),
             V1=self.wrapped_model.V1.copy().astype(FloatingPointType),
+            predict_interactions=self.predict_interactions,
+            interaction_log_transform=self.interaction_log_transform,
         )
-
-    def predict(self, data: ScreenBase) -> ArrayType:
-        state = self.get_model_state()
-        if data.treatment_arity == 1:
-            return predict_single_drug(state, data)
-        elif data.treatment_arity == 2:
-            predictions = predict(state, data)
-            if self.predict_interactions:
-                single_effects = data.single_treatment_effects
-
-                if single_effects is None:
-                    raise ValueError(
-                        "Cannot predict interactions without observed single treatment effects"
-                    )
-
-                return interactions_to_logits(
-                    predictions, single_effects, self.interaction_log_transform
-                )
-            else:
-                return predictions
-        else:
-            raise NotImplementedError("SparseDrugCombo only supports 1 or 2 treatments")
-
-    def variance(self, data: ScreenBase) -> FloatingPointType:
-        return 1.0 / self.wrapped_model.prec
 
     def step(self):
         self.wrapped_model.mcmc_step()
@@ -819,19 +677,11 @@ class SparseDrugCombo(BayesianModel, HomoscedasticModel, MCMCModel):
     def n_obs(self) -> int:
         return self.wrapped_model.n_obs()
 
-    def get_results_holder(self, n_samples: int) -> ThetaHolder:
-        return SparseDrugComboResults(
-            n_unique_samples=self.n_unique_samples,
-            n_unique_treatments=self.n_unique_treatments,
-            n_embedding_dimensions=self.n_embedding_dimensions,
-            n_thetas=n_samples,
-        )
-
     def reset_model(self):
         self.wrapped_model.reset_model()
 
 
-def predict(mcmc_sample: SparseDrugComboMCMCSample, data: ScreenBase):
+def predict(mcmc_sample: SparseDrugComboMCMCSample, data: ScreenBase, viability: bool):
     interaction2 = np.sum(
         mcmc_sample.W[data.sample_ids]
         * copy_array_with_control_treatments_set_to_zero(
@@ -865,10 +715,16 @@ def predict(mcmc_sample: SparseDrugComboMCMCSample, data: ScreenBase):
         )
     )
     Mu = intercept + interaction1 + interaction2
-    return np.clip(expit(Mu), a_min=0.01, a_max=0.99)
+
+    if viability:
+        return np.clip(expit(Mu), a_min=0.01, a_max=0.99)
+    else:
+        return Mu
 
 
-def predict_single_drug(mcmc_sample: SparseDrugComboMCMCSample, data: ScreenBase):
+def predict_single_drug(
+    mcmc_sample: SparseDrugComboMCMCSample, data: ScreenBase, viability: bool
+):
     interaction1 = np.sum(
         mcmc_sample.W[data.sample_ids]
         * copy_array_with_control_treatments_set_to_zero(
@@ -884,7 +740,11 @@ def predict_single_drug(mcmc_sample: SparseDrugComboMCMCSample, data: ScreenBase
         )
     )
     Mu = intercept + interaction1
-    return np.clip(expit(Mu), a_min=0.01, a_max=0.99)
+
+    if viability:
+        return np.clip(expit(Mu), a_min=0.01, a_max=0.99)
+    else:
+        return Mu
 
 
 def interactions_to_logits(

--- a/src/batchie/models/sparse_combo.py
+++ b/src/batchie/models/sparse_combo.py
@@ -10,10 +10,8 @@ from scipy.special import logit, expit
 
 from batchie.core import (
     BayesianModel,
-    HomoscedasticModel,
     MCMCModel,
     Theta,
-    ThetaHolder,
 )
 from batchie.data import ScreenBase
 from batchie.fast_mvn import sample_mvn_from_precision
@@ -589,7 +587,7 @@ class LegacySparseDrugComboImpl:
         return [1.0 / np.sqrt(self.prec)] + self.Mu.tolist()
 
 
-class SparseDrugCombo(BayesianModel, HomoscedasticModel, MCMCModel):
+class SparseDrugCombo(BayesianModel, MCMCModel):
     def __init__(
         self,
         n_embedding_dimensions: int,  # embedding dimension

--- a/src/batchie/models/sparse_combo_interaction.py
+++ b/src/batchie/models/sparse_combo_interaction.py
@@ -24,9 +24,6 @@ from batchie.data import ScreenBase, create_single_treatment_effect_map
 from batchie.fast_mvn import sample_mvn_from_precision
 from dataclasses import dataclass
 
-from common import ArrayType
-from data import ScreenBase
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/batchie/models/sparse_combo_interaction.py
+++ b/src/batchie/models/sparse_combo_interaction.py
@@ -46,7 +46,7 @@ class SparseDrugComboInteractionMCMCSample(Theta):
                 "SparseDrugComboInteraction only supports data sets with combinations of 2 treatments"
             )
 
-        interaction = self.predict_mean(data)
+        interaction = self.predict_conditional_mean(data)
         single_effect = np.clip(
             [
                 self.single_effect_lookup[c, dd1] * self.single_effect_lookup[c, dd2]
@@ -62,7 +62,7 @@ class SparseDrugComboInteractionMCMCSample(Theta):
         viability = np.exp(interaction + np.log(single_effect))
         return np.clip(viability, a_min=0.01, a_max=0.99)
 
-    def predict_mean(self, data: ScreenBase) -> ArrayType:
+    def predict_conditional_mean(self, data: ScreenBase) -> ArrayType:
         if not data.treatment_arity == 2:
             raise ValueError(
                 "SparseDrugComboInteraction only supports data sets with combinations of 2 treatments"
@@ -79,7 +79,7 @@ class SparseDrugComboInteractionMCMCSample(Theta):
         )
         return interaction
 
-    def predict_variance(self, data: ScreenBase) -> ArrayType:
+    def predict_conditional_variance(self, data: ScreenBase) -> ArrayType:
         v = np.repeat(1.0 / self.precision, repeats=data.size)
         return v
 

--- a/src/batchie/models/sparse_combo_interaction.py
+++ b/src/batchie/models/sparse_combo_interaction.py
@@ -16,7 +16,6 @@ from batchie.common import (
 )
 from batchie.core import (
     BayesianModel,
-    HomoscedasticModel,
     MCMCModel,
     Theta,
     ThetaHolder,
@@ -501,7 +500,7 @@ class LegacySparseDrugComboInteractionImpl:
             self.Mu = np.clip(self.Mu, self.min_Mu, self.max_Mu)
 
 
-class SparseDrugComboInteraction(BayesianModel, HomoscedasticModel, MCMCModel):
+class SparseDrugComboInteraction(BayesianModel, MCMCModel):
     def __init__(
         self,
         n_embedding_dimensions: int,  # embedding dimension

--- a/src/batchie/models/sparse_combo_test.py
+++ b/src/batchie/models/sparse_combo_test.py
@@ -4,6 +4,7 @@ import tempfile
 
 from batchie.data import Screen
 from batchie.models import sparse_combo
+from batchie.core import ThetaHolder
 
 
 @pytest.fixture
@@ -137,12 +138,7 @@ def test_results_holder_accumulate(test_dataset):
         n_unique_samples=test_dataset.n_unique_samples,
     )
 
-    results_holder = sparse_combo.SparseDrugComboResults(
-        n_thetas=2,
-        n_embedding_dimensions=5,
-        n_unique_treatments=test_dataset.treatment_arity,
-        n_unique_samples=test_dataset.n_unique_samples,
-    )
+    results_holder = ThetaHolder(n_thetas=2)
 
     while not results_holder.is_complete:
         model.step()
@@ -157,12 +153,7 @@ def test_results_holder_serde(test_dataset):
         n_unique_samples=test_dataset.n_unique_samples,
     )
 
-    results_holder = sparse_combo.SparseDrugComboResults(
-        n_thetas=2,
-        n_embedding_dimensions=5,
-        n_unique_treatments=test_dataset.treatment_arity,
-        n_unique_samples=test_dataset.n_unique_samples,
-    )
+    results_holder = ThetaHolder(n_thetas=2)
     results_holder.add_theta(model.get_model_state())
 
     # create temporary file
@@ -170,7 +161,7 @@ def test_results_holder_serde(test_dataset):
     with tempfile.NamedTemporaryFile() as f:
         results_holder.save_h5(f.name)
 
-        results_holder2 = sparse_combo.SparseDrugComboResults.load_h5(f.name)
+        results_holder2 = ThetaHolder.load_h5(f.name)
 
     assert results_holder2.n_unique_samples == results_holder.n_thetas
     np.testing.assert_array_equal(results_holder2.V2, results_holder.V2)

--- a/src/batchie/retrospective.py
+++ b/src/batchie/retrospective.py
@@ -748,21 +748,15 @@ def reveal_plates(
     )
 
 
-def calculate_mse(
-    observed_screen: Screen,
-    model: BayesianModel,
-    thetas: ThetaHolder,
-) -> float:
+def calculate_mse(observed_screen: Screen, thetas: ThetaHolder) -> float:
     """
     Calculate the mean squared error between the masked observations and the unmasked observations
 
     :param observed_screen: A :py:class:`Screen` that is fully observed
-    :param model: The model to use for prediction
     :param thetas: The set of model parameters to use for prediction
     :return: The average mean squared error between predicted and observed values
     """
     preds = predict_viability_avg(
-        model=model,
         screen=observed_screen,
         thetas=thetas,
     )

--- a/src/batchie/retrospective.py
+++ b/src/batchie/retrospective.py
@@ -15,7 +15,7 @@ from batchie.core import (
     RetrospectivePlateSmoother,
 )
 from batchie.data import Screen, Plate
-from batchie.models.main import predict_avg
+from batchie.models.main import predict_viability_avg
 
 logger = logging.getLogger(__name__)
 
@@ -761,7 +761,7 @@ def calculate_mse(
     :param thetas: The set of model parameters to use for prediction
     :return: The average mean squared error between predicted and observed values
     """
-    preds = predict_avg(
+    preds = predict_viability_avg(
         model=model,
         screen=observed_screen,
         thetas=thetas,

--- a/src/batchie/retrospective_test.py
+++ b/src/batchie/retrospective_test.py
@@ -5,7 +5,7 @@ import numpy.testing
 import pytest
 
 from batchie import retrospective
-from batchie.core import BayesianModel, ThetaHolder
+from batchie.core import BayesianModel, ThetaHolder, Theta
 from batchie.data import Screen
 
 
@@ -326,17 +326,17 @@ def test_reveal_plates_catches_nan(masked_dataset):
         )
 
 
-def test_calculate_mse(test_dataset):
-    model = mock.MagicMock(BayesianModel)
-    model.predict.return_value = 1.0
-
-    samples_holder = mock.MagicMock(ThetaHolder)
+def test_calculate_mse(test_dataset, mocker):
+    samples_holder = mocker.MagicMock(ThetaHolder)
     samples_holder.n_thetas = 10
 
+    theta = mocker.MagicMock(Theta)
+    theta.predict_viability.return_value = np.ones(test_dataset.size)
+
+    samples_holder.get_theta.return_value = theta
+
     result = retrospective.calculate_mse(
-        observed_screen=test_dataset,
-        thetas=samples_holder,
-        model=model,
+        observed_screen=test_dataset, thetas=samples_holder
     )
 
     assert result == np.mean(

--- a/src/batchie/scoring/gaussian_dbal.py
+++ b/src/batchie/scoring/gaussian_dbal.py
@@ -14,9 +14,8 @@ from batchie.core import (
 from batchie.data import ScreenSubset
 from batchie.distance_calculation import ChunkedDistanceMatrix
 from batchie.models.main import (
-    predict_all,
-    get_heteroescedastic_variances,
-    get_homoescedastic_variances,
+    predict_mean_all,
+    predict_variance_all,
 )
 
 
@@ -294,46 +293,39 @@ class GaussianDBALScorer(Scorer):
                 else:
                     plate_subgroup_mask = plate_subgroup_mask | plate.selection_vector
 
-            per_plate_predictions = [
-                predict_all(screen=plate, model=model, thetas=samples)
+            per_plate_means = [
+                predict_mean_all(screen=plate, thetas=samples)
                 for plate in current_plates
             ]
 
-            match model:
-                case HomoscedasticModel():
-                    variances = np.vstack(
-                        [
-                            get_homoescedastic_variances(
-                                model=model, screen=plate, thetas=samples
-                            )
-                            for plate in current_plates
-                        ]
-                    )
-                    vals = dbal_fast_gaussian_scoring_homoscedastic(
-                        per_plate_predictions=per_plate_predictions,
-                        variances=variances,
-                        distance_matrix=dense_distance_matrix,
-                        rng=rng,
-                        max_combos=self.max_triples,
-                    )
-                case HeteroscedasticModel():
-                    variances = [
-                        get_heteroescedastic_variances(
-                            model=model, screen=plate, thetas=samples
-                        )
-                        for plate in current_plates
-                    ]
-                    vals = dbal_fast_gaussian_scoring_heteroscedastic(
-                        per_plate_predictions=per_plate_predictions,
-                        variances=variances,
-                        distance_matrix=dense_distance_matrix,
-                        rng=rng,
-                        max_combos=self.max_triples,
-                    )
-                case other:
+            per_plate_variances = [
+                predict_variance_all(screen=plate, thetas=samples)
+                for plate in current_plates
+            ]
+
+            for plate_predictions, plate_variances in zip(
+                per_plate_means, per_plate_variances
+            ):
+                if plate_predictions.shape != plate_variances.shape:
                     raise ValueError(
-                        f"Method not supported for model type: {type(other)}"
+                        "plate_predictions and plate_variances must have the same shape"
                     )
+
+            padded_means = pad_ragged_arrays_to_dense_array(
+                per_plate_means, pad_value=0.0
+            )
+
+            padded_variances = pad_ragged_arrays_to_dense_array(
+                per_plate_variances, pad_value=np.nan
+            )
+
+            vals = dbal_fast_gauss_scoring_vectorized(
+                predictions=padded_means,
+                variances=padded_variances,
+                distance_matrix=distance_matrix,
+                rng=rng,
+                max_combos=self.max_triples,
+            )
 
             result.update(dict(zip(plate_subgroup, vals)))
             progress_bar.update(len(current_plates))

--- a/src/batchie/scoring/gaussian_dbal.py
+++ b/src/batchie/scoring/gaussian_dbal.py
@@ -7,8 +7,6 @@ from batchie.common import ArrayType
 from batchie.core import (
     Scorer,
     BayesianModel,
-    HomoscedasticModel,
-    HeteroscedasticModel,
     ThetaHolder,
 )
 from batchie.data import ScreenSubset

--- a/src/batchie/scoring/gaussian_dbal.py
+++ b/src/batchie/scoring/gaussian_dbal.py
@@ -320,7 +320,7 @@ class GaussianDBALScorer(Scorer):
             vals = dbal_fast_gauss_scoring_vectorized(
                 predictions=padded_means,
                 variances=padded_variances,
-                distance_matrix=distance_matrix,
+                distance_matrix=dense_distance_matrix,
                 rng=rng,
                 max_combos=self.max_triples,
             )

--- a/src/batchie/scoring/gaussian_dbal_test.py
+++ b/src/batchie/scoring/gaussian_dbal_test.py
@@ -5,8 +5,6 @@ import pytest
 
 from batchie.core import (
     BayesianModel,
-    HomoscedasticModel,
-    HeteroscedasticModel,
     Screen,
     ThetaHolder,
     ScreenSubset,
@@ -318,7 +316,7 @@ def test_gaussian_dbal_scorer_homoscedastic(
 
     assert chunked_distance_matrix.is_complete()
 
-    class M(BayesianModel, HomoscedasticModel):
+    class M(BayesianModel):
         pass
 
     model = mock.Mock(spec=M)
@@ -354,7 +352,7 @@ def test_gaussian_dbal_scorer_heteroscedastic(
 
     assert chunked_distance_matrix.is_complete()
 
-    class M(BayesianModel, HeteroscedasticModel):
+    class M(BayesianModel):
         pass
 
     model = mock.Mock(spec=M)
@@ -390,7 +388,7 @@ def test_gaussian_dbal_scorer_subsets(
 
     assert chunked_distance_matrix.is_complete()
 
-    class M(BayesianModel, HomoscedasticModel):
+    class M(BayesianModel):
         pass
 
     model = mock.Mock(spec=M)
@@ -427,7 +425,7 @@ def test_gaussian_dbal_scorer_empty(unobserved_dataset, chunked_distance_matrix)
 
     assert chunked_distance_matrix.is_complete()
 
-    class M(BayesianModel, HomoscedasticModel):
+    class M(BayesianModel):
         pass
 
     model = mock.Mock(spec=M)

--- a/src/batchie/scoring/gaussian_dbal_test.py
+++ b/src/batchie/scoring/gaussian_dbal_test.py
@@ -7,10 +7,12 @@ from batchie.core import (
     BayesianModel,
     Screen,
     ThetaHolder,
+    Theta,
     ScreenSubset,
 )
 from batchie.distance_calculation import ChunkedDistanceMatrix
 from batchie.scoring import gaussian_dbal
+from batchie.common import FloatingPointType
 
 
 @pytest.fixture
@@ -308,59 +310,26 @@ def test_dbal_fast_gaussian_scoring_heteroscedastic():
     assert np.argmin(result) == 9
 
 
-def test_gaussian_dbal_scorer_homoscedastic(
-    mocker, unobserved_dataset, chunked_distance_matrix
-):
+def test_gaussian_dbal_scorer(mocker, unobserved_dataset, chunked_distance_matrix):
     rng = np.random.default_rng(0)
     scorer = gaussian_dbal.GaussianDBALScorer(max_chunk=2, max_triples=5000)
 
     assert chunked_distance_matrix.is_complete()
 
-    class M(BayesianModel):
-        pass
-
-    model = mock.Mock(spec=M)
+    model = mock.MagicMock(BayesianModel)
     theta_holder = mock.MagicMock(ThetaHolder)
 
-    theta_holder.n_thetas = chunked_distance_matrix.size
-    model.predict.return_value = 1.0
-    model.variance.return_value = 1.0
+    theta_holder.n_thetas.return_value = chunked_distance_matrix.size
 
-    plates = {p.plate_id: p for p in unobserved_dataset.plates}
+    theta = mocker.Mock(Theta)
 
-    mocker.patch(
-        "batchie.scoring.gaussian_dbal.dbal_fast_gauss_scoring_vectorized",
-        return_value=np.array([1.0, 2.0, 3.0, 4.0]),
-    )
+    def fake_predict(data: Screen):
+        return np.ones(data.size, dtype=FloatingPointType)
 
-    result = scorer.score(
-        model=model,
-        plates=plates,
-        distance_matrix=chunked_distance_matrix,
-        samples=theta_holder,
-        rng=rng,
-        progress_bar=False,
-    )
-    assert result == {0: 1.0, 1: 2.0, 2: 1.0, 3: 2.0}
-
-
-def test_gaussian_dbal_scorer_heteroscedastic(
-    mocker, unobserved_dataset, chunked_distance_matrix
-):
-    rng = np.random.default_rng(0)
-    scorer = gaussian_dbal.GaussianDBALScorer(max_chunk=2, max_triples=5000)
-
-    assert chunked_distance_matrix.is_complete()
-
-    class M(BayesianModel):
-        pass
-
-    model = mock.Mock(spec=M)
-    theta_holder = mock.MagicMock(ThetaHolder)
-
-    theta_holder.n_thetas = chunked_distance_matrix.size
-    model.predict.return_value = 1.0
-    model.variance.return_value = np.ones((2,))
+    theta.predict_conditional_variance.side_effect = fake_predict
+    theta.predict_viability.side_effect = fake_predict
+    theta.predict_conditional_mean.side_effect = fake_predict
+    theta_holder.get_theta.return_value = theta
 
     plates = {p.plate_id: p for p in unobserved_dataset.plates}
 
@@ -388,15 +357,20 @@ def test_gaussian_dbal_scorer_subsets(
 
     assert chunked_distance_matrix.is_complete()
 
-    class M(BayesianModel):
-        pass
-
-    model = mock.Mock(spec=M)
+    model = mock.MagicMock(BayesianModel)
     theta_holder = mock.MagicMock(ThetaHolder)
 
-    theta_holder.n_thetas = chunked_distance_matrix.size
-    model.predict.return_value = 1.0
-    model.variance.return_value = 1.0
+    theta_holder.n_thetas.return_value = chunked_distance_matrix.size
+
+    theta = mocker.Mock(Theta)
+
+    def fake_predict(data: Screen):
+        return np.ones(data.size, dtype=FloatingPointType)
+
+    theta.predict_conditional_variance.side_effect = fake_predict
+    theta.predict_viability.side_effect = fake_predict
+    theta.predict_conditional_mean.side_effect = fake_predict
+    theta_holder.get_theta.return_value = theta
 
     plates = {p.plate_id: p for p in unobserved_dataset.plates}
     subsets = {}
@@ -419,21 +393,28 @@ def test_gaussian_dbal_scorer_subsets(
     assert result == {0: 1.0, 1: 2.0, 2: 1.0, 3: 2.0}
 
 
-def test_gaussian_dbal_scorer_empty(unobserved_dataset, chunked_distance_matrix):
+def test_gaussian_dbal_scorer_empty(
+    mocker, unobserved_dataset, chunked_distance_matrix
+):
     rng = np.random.default_rng(0)
     scorer = gaussian_dbal.GaussianDBALScorer(max_chunk=2, max_triples=5000)
 
     assert chunked_distance_matrix.is_complete()
 
-    class M(BayesianModel):
-        pass
-
-    model = mock.Mock(spec=M)
+    model = mock.MagicMock(BayesianModel)
     theta_holder = mock.MagicMock(ThetaHolder)
 
-    theta_holder.n_thetas = chunked_distance_matrix.size
-    model.predict.return_value = 1.0
-    model.variance.return_value = 1.0
+    theta_holder.n_thetas.return_value = chunked_distance_matrix.size
+
+    theta = mocker.Mock(Theta)
+
+    def fake_predict(data: Screen):
+        return np.ones(data.size, dtype=FloatingPointType)
+
+    theta.predict_conditional_variance.side_effect = fake_predict
+    theta.predict_viability.side_effect = fake_predict
+    theta.predict_conditional_mean.side_effect = fake_predict
+    theta_holder.get_theta.return_value = theta
 
     res = scorer.score(
         model=model,


### PR DESCRIPTION
Restructured BayesianModel, Theta, ThetaHolder relationship.

1. `Theta` now contains all prediction methods, e.g., `predict_conditional_mean`, predict_conditional_variance. 
2. Prediction now explicitly delineates between the model's conditional mean (`predict_conditional_mean`) and predictions in viability space (`predict_viability`).
3. Serialization now happens at the `Theta` level through the `private_parameters_dict`, `from_dicts`, and (optionally) `shared_parameters_dict` methods.
4. `ThetaHolder` no longer needs to be implemented per-class.